### PR TITLE
Add system for downloading files in segments

### DIFF
--- a/Download/DownloadProgressUpdater.cs
+++ b/Download/DownloadProgressUpdater.cs
@@ -42,6 +42,7 @@
                 progressWindow.percentageDone = totalProgress;
                 progressWindow.Text = $"Downloading {progressWindow.fileName}... ({totalProgress}%)";
                 progressWindow.progressLabel.Text = $"{((double)progress0 + (double)progress1) / 2}%";
+                progressWindow.totalProgress = totalProgress;
             }));
         }
     }

--- a/Download/DownloadProgressUpdater.cs
+++ b/Download/DownloadProgressUpdater.cs
@@ -39,6 +39,7 @@
             {
                 progressWindow.bytesLabel.Text = $"({totalRead} B / {totalLength} B)";
                 totalProgress = ((int)progress0 + (int)progress1) / 2;
+                progressWindow.percentageDone = totalProgress;
                 progressWindow.Text = $"Downloading {progressWindow.fileName}... ({totalProgress}%)";
                 progressWindow.progressLabel.Text = $"{((double)progress0 + (double)progress1) / 2}%";
             }));

--- a/Download/DownloadProgressUpdater.cs
+++ b/Download/DownloadProgressUpdater.cs
@@ -1,0 +1,47 @@
+﻿namespace DownloadManager.Download
+{
+    internal class DownloadProgressUpdater
+    {
+        // DownloadSegment0
+        public long contentLength0 = 0;
+        public long read0 = 0;
+        public long progress0 = 0;
+
+        // DownloadSegment1
+        public long contentLength1 = 0;
+        public long read1 = 0;
+        public long progress1 = 0;
+
+        // Total
+        public long totalLength = 0;
+        private long totalRead = 0;
+        private int totalProgress = 0;
+
+        // Other
+        internal DownloadProgress progressWindow;
+
+        public void Initialize(long totalLength, DownloadProgress window)
+        {
+            this.totalLength = totalLength;
+            this.progressWindow = window;
+            UpdateUI();
+        }
+
+        public void UpdateUI()
+        {
+            totalRead = read0 + read1;
+            if (progressWindow == null)
+            {
+                return;
+            }
+
+            progressWindow.Invoke(new MethodInvoker(delegate
+            {
+                progressWindow.bytesLabel.Text = $"({totalRead} B / {totalLength} B)";
+                totalProgress = ((int)progress0 + (int)progress1) / 2;
+                progressWindow.Text = $"Downloading {progressWindow.fileName}... ({totalProgress}%)";
+                progressWindow.progressLabel.Text = $"{((double)progress0 + (double)progress1) / 2}%";
+            }));
+        }
+    }
+}

--- a/Download/DownloadSegment.cs
+++ b/Download/DownloadSegment.cs
@@ -1,0 +1,86 @@
+﻿namespace DownloadManager.Download
+{
+    internal class DownloadSegment
+    {
+        DownloadProgress progressWindow;
+        bool div0 = false;
+
+        public async Task DownloadFileSegment(DownloadSegmentID id, DownloadProgress window, Stream downloadStream, Stream outputStream, long contentLength, long totalLength, string location, BetterProgressBar progressBar, CancellationToken token, DownloadProgressUpdater progressUpdater)
+        {
+            Action<BetterProgressBar, long, long, long> progressCallback = new Action<BetterProgressBar, long, long, long>(SegmentProgressCallback);
+            progressWindow = window;
+
+            byte[] buffer = new byte[8 * 1024];
+            int len;
+            long totalRead = 0;
+
+            while ((len = await downloadStream.ReadAsync(buffer, 0, buffer.Length).ConfigureAwait(false)) > 0)
+            {
+                await outputStream.WriteAsync(buffer, 0, len).ConfigureAwait(false);
+                totalRead += len;
+                progressCallback.Invoke(progressBar, totalRead, contentLength, totalLength);
+
+                switch (id)
+                {
+                    case DownloadSegmentID.Segment0:
+                        progressUpdater.read0 = totalRead;
+                        progressUpdater.progress0 = (int)((double)totalRead / (double)contentLength * (double)100);
+                        break;
+                    case DownloadSegmentID.Segment1:
+                        progressUpdater.read1 = totalRead;
+                        progressUpdater.progress1 = (int)((double)totalRead / (double)contentLength * (double)100);
+                        break;
+                }
+            }
+
+            if (progressCallback != null && totalLength != -1)
+            {
+                //Debug.Assert(totalRead == totalLength);
+            }
+
+            await outputStream.FlushAsync().ConfigureAwait(false);
+            outputStream.Close();
+        }
+
+        private void SegmentProgressCallback(BetterProgressBar progressBar, long totalRead, long contentLength, long totalLength)
+        {
+            if (!div0 && contentLength == 0)
+            {
+                DarkMessageBox errMsg = new DarkMessageBox($"contentLength is 0, this will cause a DivideByZeroException.\nThe file will still download but progress reporting will be unavailable.\nDebug Information:\ntotalRead = {totalRead}\ncontentLength = {contentLength}", "Download Manager - Progress Callback", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                errMsg.ShowDialog();
+                div0 = true;
+                return;
+            }
+            else if (div0)
+            {
+                return;
+            }
+
+            double percentageDone = (double)totalRead / (double)contentLength * (double)100; // number (36561) / number (524289) * 100 = 0???????
+
+            /*try
+            {
+                percentageDone = totalRead / contentLength * 100;
+            }
+            catch (Exception ex)
+            {
+                DarkMessageBox errMsg = new DarkMessageBox($"{ex.Message} ({ex.GetType().FullName})\nGot Value: {percentageDone}\nOther Values:\ntotalRead: {totalRead}\ncontentLength: {contentLength}\n{ex.StackTrace}", "Download Manager", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                errMsg.ShowDialog();
+            }*/
+
+
+            progressWindow.Invoke(new MethodInvoker(delegate
+            {
+                progressBar.Minimum = 0;
+                progressBar.Maximum = 100;
+                progressBar.Value = (int)percentageDone;
+            }));
+        }
+
+        public enum DownloadSegmentID
+        {
+            Segment0,
+            Segment1
+        }
+    }
+}

--- a/Download/DownloadSegment.cs
+++ b/Download/DownloadSegment.cs
@@ -108,7 +108,7 @@ namespace DownloadManager.Download
                         //progressWindow.cancellationToken.Cancel();
                         //progressWindow.cancellationToken.Dispose();
 
-                        progressWindow.CancelButton.PerformClick();
+                        progressWindow.cancelButton.PerformClick();
 
                         progressWindow.updateDisplayTimer.Stop();
                         progressWindow.updateDisplayTimer.Dispose();

--- a/Download/DownloadSegment.cs
+++ b/Download/DownloadSegment.cs
@@ -2,6 +2,7 @@
 {
     internal class DownloadSegment
     {
+        public bool isDownloading = true;
         DownloadProgress progressWindow;
         bool div0 = false;
 
@@ -40,6 +41,7 @@
 
             await outputStream.FlushAsync().ConfigureAwait(false);
             outputStream.Close();
+            isDownloading = false;
         }
 
         private void SegmentProgressCallback(BetterProgressBar progressBar, long totalRead, long contentLength, long totalLength)

--- a/Download/DownloadSegment.cs
+++ b/Download/DownloadSegment.cs
@@ -69,17 +69,6 @@ namespace DownloadManager.Download
 
             double percentageDone = (double)totalRead / (double)contentLength * (double)100;
 
-            /*try
-            {
-                percentageDone = totalRead / contentLength * 100;
-            }
-            catch (Exception ex)
-            {
-                DarkMessageBox errMsg = new DarkMessageBox($"{ex.Message} ({ex.GetType().FullName})\nGot Value: {percentageDone}\nOther Values:\ntotalRead: {totalRead}\ncontentLength: {contentLength}\n{ex.StackTrace}", "Download Manager", MessageBoxButtons.OK, MessageBoxIcon.Error);
-                errMsg.ShowDialog();
-            }*/
-
-
             progressWindow.Invoke(new MethodInvoker(delegate
             {
                 try
@@ -105,9 +94,6 @@ namespace DownloadManager.Download
                         int hashTypeArg = progressWindow.hashType;
                         int downloadAttempts = progressWindow.downloadAttempts;
 
-                        //progressWindow.cancellationToken.Cancel();
-                        //progressWindow.cancellationToken.Dispose();
-
                         progressWindow.cancelButton.PerformClick();
 
                         progressWindow.updateDisplayTimer.Stop();
@@ -117,9 +103,6 @@ namespace DownloadManager.Download
                         new ToastContentBuilder()
                                  .AddText($"The download of {progressWindow.fileName} failed to prevent a crash. The download will now restart in safe mode.")
                                  .Show();
-
-                        /*progressWindow.Close();
-                        progressWindow.Dispose();*/
 
                         DownloadProgress safeDownload = new DownloadProgress(url, location, downloadType, youtubeDownloadType, hashArg, hashTypeArg, downloadAttempts, true);
                         safeDownload.Show();

--- a/DownloadItem.cs
+++ b/DownloadItem.cs
@@ -153,17 +153,19 @@ namespace DownloadManager
                 {
                     // Update the progress bar
                     progressBar.Style = ProgressBarStyle.Blocks;
-                    progressBar.Minimum = progress.progressBar1.Minimum;
-                    progressBar.Maximum = progress.progressBar1.Maximum;
-                    progressBar.Value = progress.progressBar1.Value;
+                    progressBar.Minimum = progress.totalProgressBar.Minimum;
+                    progressBar.Maximum = progress.totalProgressBar.Maximum;
+                    progressBar.Value = progress.totalProgressBar.Value;
 
                     // Update the progress label
-                    int percent = (int)(((double)progress.progressBar1.Value / (double)progress.progressBar1.Maximum) * 100);
+                    int percent = (int)(((double)progressBar.Value / (double)progressBar.Maximum) * 100);
                     fileProgressLabel.Text = $"{percent}%";
                 }
                 else if (progress.downloadType == DownloadProgress.DownloadType.YoutubeVideo)
                 {
                     progressBar.Style = ProgressBarStyle.Marquee;
+                    progressBar.MarqueeAnim = true;
+                    progressBar.ShowText = false;
                 }
                 else
                 {

--- a/DownloadItem.cs
+++ b/DownloadItem.cs
@@ -10,6 +10,7 @@ namespace DownloadManager
         DownloadProgress progress;
         GroupBox groupBox;
         bool isYtDownload = false;
+        bool contentLengthIssue = false;
 
         #region Predefined Controls
         BetterProgressBar progressBar = new BetterProgressBar()
@@ -170,11 +171,11 @@ namespace DownloadManager
                 else
                 {
                     // Update the progress bar
-                    progressBar.Style = ProgressBarStyle.Blocks;
-                    progressBar.Value = (int)progress.percentageDone;
-
-                    // Update the progress label
-                    fileProgressLabel.Text = progress.percentageDone.ToString() + "%";
+                    if ((int)progress.percentageDone > 100)
+                    {
+                        Logging.Log("DownloadItem Progress is greater than 100%! The item has been removed to prevent a crash!", Color.Orange);
+                        Dispose();
+                    }
                 }
 
                 // Bring all labels to front

--- a/DownloadItem.cs
+++ b/DownloadItem.cs
@@ -148,7 +148,14 @@ namespace DownloadManager
                 // Update the labels
                 fileNameLabel.Text = progress.fileName;
                 fileUrlLabel.Text = progress.url;
-                fileSizeLabel.Text = progress.fileSize + " Bytes";
+                if (progress.totalSize < 1)
+                {
+                    fileSizeLabel.Text = "? Bytes";
+                }
+                else
+                {
+                    fileSizeLabel.Text = progress.fileSize + " Bytes";
+                }
 
                 if (progress.downloadType == DownloadProgress.DownloadType.YoutubePlaylist)
                 {

--- a/DownloadItem.cs
+++ b/DownloadItem.cs
@@ -176,6 +176,29 @@ namespace DownloadManager
                         Logging.Log("DownloadItem Progress is greater than 100%! The item has been removed to prevent a crash!", Color.Orange);
                         Dispose();
                     }
+
+                    if (progress.totalSize < 1)
+                    {
+                        // If the total size is less than 1, then we cannot report progress
+                        // Update the progress bar
+                        progressBar.Style = ProgressBarStyle.Marquee;
+                        progressBar.MarqueeAnim = true;
+
+                        // Update the progress label
+                        fileProgressLabel.Text = $"Progress report unavailable.";
+                    }
+                    else
+                    {
+                        // Update the progress bar
+                        progressBar.Style = ProgressBarStyle.Blocks;
+                        progressBar.Minimum = 0;
+                        progressBar.Maximum = 100;
+                        progressBar.Value = progress.totalProgress;
+
+                        // Update the progress label
+                        int percent = (int)(((double)progressBar.Value / (double)progressBar.Maximum) * 100);
+                        fileProgressLabel.Text = $"{percent}%";
+                    }
                 }
 
                 // Bring all labels to front

--- a/DownloadProgress.Designer.cs
+++ b/DownloadProgress.Designer.cs
@@ -326,7 +326,6 @@
         private System.Windows.Forms.Label label2;
         private System.Windows.Forms.Label label3;
         private System.Windows.Forms.CheckBox checkBox1;
-        private System.Windows.Forms.Button cancelButton;
         private System.Windows.Forms.CheckBox checkBox2;
         private Label hashLabel;
         private Splitter splitter1;
@@ -343,5 +342,6 @@
         public Label progressLabel;
         public System.Windows.Forms.Timer updateDisplayTimer;
         private Label safeModeLabel;
+        public Button cancelButton;
     }
 }

--- a/DownloadProgress.Designer.cs
+++ b/DownloadProgress.Designer.cs
@@ -32,7 +32,7 @@
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(DownloadProgress));
             updateDisplayTimer = new System.Windows.Forms.Timer(components);
             urlLabel = new Label();
-            label3 = new Label();
+            progressLabel = new Label();
             checkBox1 = new CheckBox();
             cancelButton = new Button();
             checkBox2 = new CheckBox();
@@ -69,18 +69,18 @@
             urlLabel.TabIndex = 7;
             urlLabel.Text = "file from server";
             // 
-            // label3
+            // progressLabel
             // 
-            label3.AutoSize = true;
-            label3.BackColor = Color.Black;
-            label3.FlatStyle = FlatStyle.Flat;
-            label3.ForeColor = Color.White;
-            label3.Location = new Point(13, 149);
-            label3.Margin = new Padding(4, 0, 4, 0);
-            label3.Name = "label3";
-            label3.Size = new Size(41, 16);
-            label3.TabIndex = 9;
-            label3.Text = "0.00%";
+            progressLabel.AutoSize = true;
+            progressLabel.BackColor = Color.Black;
+            progressLabel.FlatStyle = FlatStyle.Flat;
+            progressLabel.ForeColor = Color.White;
+            progressLabel.Location = new Point(13, 149);
+            progressLabel.Margin = new Padding(4, 0, 4, 0);
+            progressLabel.Name = "progressLabel";
+            progressLabel.Size = new Size(41, 16);
+            progressLabel.TabIndex = 9;
+            progressLabel.Text = "0.00%";
             // 
             // checkBox1
             // 
@@ -290,7 +290,7 @@
             Controls.Add(checkBox2);
             Controls.Add(cancelButton);
             Controls.Add(checkBox1);
-            Controls.Add(label3);
+            Controls.Add(progressLabel);
             Controls.Add(urlLabel);
             Controls.Add(totalProgressBar);
             ForeColor = Color.White;
@@ -324,10 +324,11 @@
         private Label label1;
         private Button openButton;
         private Button pauseButton;
-        private Label bytesLabel;
         public BetterProgressBar progressBar1;
         private CheckBox checkBox3;
         public BetterProgressBar progressBar2;
         public BetterProgressBar totalProgressBar;
+        public Label bytesLabel;
+        public Label progressLabel;
     }
 }

--- a/DownloadProgress.Designer.cs
+++ b/DownloadProgress.Designer.cs
@@ -46,6 +46,8 @@
             pauseButton = new Button();
             bytesLabel = new Label();
             checkBox3 = new CheckBox();
+            progressBar2 = new BetterProgressBar();
+            totalProgressBar = new BetterProgressBar();
             ((System.ComponentModel.ISupportInitialize)pictureBox1).BeginInit();
             SuspendLayout();
             // 
@@ -155,7 +157,7 @@
             progressBar1.BackColor = Color.FromArgb(20, 20, 20);
             progressBar1.Location = new Point(12, 122);
             progressBar1.Name = "progressBar1";
-            progressBar1.Size = new Size(416, 25);
+            progressBar1.Size = new Size(207, 25);
             progressBar1.TabIndex = 18;
             // 
             // pictureBox1
@@ -251,12 +253,31 @@
             checkBox3.Text = "Open this file when the download completes";
             checkBox3.UseVisualStyleBackColor = false;
             // 
+            // progressBar2
+            // 
+            progressBar2.BackColor = Color.FromArgb(20, 20, 20);
+            progressBar2.Location = new Point(221, 122);
+            progressBar2.Name = "progressBar2";
+            progressBar2.Size = new Size(207, 25);
+            progressBar2.TabIndex = 26;
+            // 
+            // totalProgressBar
+            // 
+            totalProgressBar.BackColor = Color.FromArgb(20, 20, 20);
+            totalProgressBar.Location = new Point(12, 122);
+            totalProgressBar.Name = "totalProgressBar";
+            totalProgressBar.Size = new Size(414, 25);
+            totalProgressBar.TabIndex = 27;
+            totalProgressBar.Visible = false;
+            // 
             // DownloadProgress
             // 
             AutoScaleDimensions = new SizeF(7F, 16F);
             AutoScaleMode = AutoScaleMode.Font;
             BackColor = Color.Black;
             ClientSize = new Size(439, 289);
+            Controls.Add(totalProgressBar);
+            Controls.Add(progressBar2);
             Controls.Add(checkBox3);
             Controls.Add(bytesLabel);
             Controls.Add(pauseButton);
@@ -306,5 +327,7 @@
         private Label bytesLabel;
         public BetterProgressBar progressBar1;
         private CheckBox checkBox3;
+        public BetterProgressBar progressBar2;
+        public BetterProgressBar totalProgressBar;
     }
 }

--- a/DownloadProgress.Designer.cs
+++ b/DownloadProgress.Designer.cs
@@ -276,7 +276,6 @@
             AutoScaleMode = AutoScaleMode.Font;
             BackColor = Color.Black;
             ClientSize = new Size(439, 289);
-            Controls.Add(totalProgressBar);
             Controls.Add(progressBar2);
             Controls.Add(checkBox3);
             Controls.Add(bytesLabel);
@@ -293,6 +292,7 @@
             Controls.Add(checkBox1);
             Controls.Add(label3);
             Controls.Add(urlLabel);
+            Controls.Add(totalProgressBar);
             ForeColor = Color.White;
             FormBorderStyle = FormBorderStyle.FixedSingle;
             Icon = (Icon)resources.GetObject("$this.Icon");

--- a/DownloadProgress.Designer.cs
+++ b/DownloadProgress.Designer.cs
@@ -48,6 +48,7 @@
             checkBox3 = new CheckBox();
             progressBar2 = new BetterProgressBar();
             totalProgressBar = new BetterProgressBar();
+            safeModeLabel = new Label();
             ((System.ComponentModel.ISupportInitialize)pictureBox1).BeginInit();
             SuspendLayout();
             // 
@@ -270,12 +271,23 @@
             totalProgressBar.TabIndex = 27;
             totalProgressBar.Visible = false;
             // 
+            // safeModeLabel
+            // 
+            safeModeLabel.AutoSize = true;
+            safeModeLabel.Location = new Point(368, 4);
+            safeModeLabel.Name = "safeModeLabel";
+            safeModeLabel.Size = new Size(66, 16);
+            safeModeLabel.TabIndex = 28;
+            safeModeLabel.Text = "Safe Mode";
+            safeModeLabel.Visible = false;
+            // 
             // DownloadProgress
             // 
             AutoScaleDimensions = new SizeF(7F, 16F);
             AutoScaleMode = AutoScaleMode.Font;
             BackColor = Color.Black;
             ClientSize = new Size(439, 289);
+            Controls.Add(safeModeLabel);
             Controls.Add(progressBar2);
             Controls.Add(checkBox3);
             Controls.Add(bytesLabel);
@@ -310,7 +322,6 @@
         }
 
         #endregion
-        private System.Windows.Forms.Timer updateDisplayTimer;
         private System.Windows.Forms.Label urlLabel;
         private System.Windows.Forms.Label label2;
         private System.Windows.Forms.Label label3;
@@ -330,5 +341,7 @@
         public BetterProgressBar totalProgressBar;
         public Label bytesLabel;
         public Label progressLabel;
+        public System.Windows.Forms.Timer updateDisplayTimer;
+        private Label safeModeLabel;
     }
 }

--- a/DownloadProgress.cs
+++ b/DownloadProgress.cs
@@ -111,8 +111,11 @@ namespace DownloadManager
             Log("Preparing to start downloading...", Color.White);
             checkBox2.Checked = Settings.Default.closeOnComplete;
             checkBox1.Checked = Settings.Default.keepOnTop;
-            progressBar1.Style = ProgressBarStyle.Marquee;
-            progressBar1.MarqueeAnim = true;
+            progressBar1.Visible = false;
+            progressBar2.Visible = false;
+            totalProgressBar.Visible = true;
+            totalProgressBar.Style = ProgressBarStyle.Marquee;
+            totalProgressBar.MarqueeAnim = true;
             if (doSafeMode)
             {
                 Log("Safe mode flag is set!", Color.Orange);
@@ -1019,10 +1022,10 @@ namespace DownloadManager
             {
                 this.Invoke(new MethodInvoker(delegate ()
                 {
-                    progressBar1.Value = 100;
-                    progressBar1.State = ProgressBarState.Error;
-                    progressBar1.ShowText = false;
-                    progressBar1.Style = ProgressBarStyle.Blocks;
+                    totalProgressBar.Value = 100;
+                    totalProgressBar.State = ProgressBarState.Error;
+                    totalProgressBar.ShowText = false;
+                    totalProgressBar.Style = ProgressBarStyle.Blocks;
                 }));
 
                 downloading = false;
@@ -1205,8 +1208,11 @@ namespace DownloadManager
 
             this.Invoke(new MethodInvoker(delegate ()
             {
-                progressBar1.Style = ProgressBarStyle.Blocks;
-                progressBar1.MarqueeAnim = false;
+                totalProgressBar.Style = ProgressBarStyle.Blocks;
+                totalProgressBar.MarqueeAnim = false;
+                totalProgressBar.Visible = false;
+                progressBar1.Visible = true;
+                progressBar2.Visible = true;
             }));
 
             Log("Downloading file " + uri + " to " + location + fileName, Color.White);
@@ -1244,10 +1250,13 @@ namespace DownloadManager
                 {
                     Invoke(new MethodInvoker(delegate
                     {
-                        progressBar1.Style = ProgressBarStyle.Blocks;
-                        progressBar1.MarqueeAnim = false;
-                        progressBar1.Value = 100;
-                        progressBar1.State = ProgressBarState.Error;
+                        progressBar1.Visible = false;
+                        progressBar2.Visible = false;
+                        totalProgressBar.Visible = true;
+                        totalProgressBar.Style = ProgressBarStyle.Blocks;
+                        totalProgressBar.MarqueeAnim = false;
+                        totalProgressBar.Value = 100;
+                        totalProgressBar.State = ProgressBarState.Error;
                     }));
                 }
 
@@ -1753,8 +1762,11 @@ namespace DownloadManager
                 {
                     Invoke(new MethodInvoker(delegate ()
                     {
-                        progressBar1.Style = ProgressBarStyle.Marquee;
-                        progressBar1.MarqueeAnim = true;
+                        progressBar1.Visible = false;
+                        progressBar2.Visible = false;
+                        totalProgressBar.Visible = true;
+                        totalProgressBar.Style = ProgressBarStyle.Marquee;
+                        totalProgressBar.MarqueeAnim = true;
                         if (!isUrlInvalid)
                         {
                             if (doFileVerify)
@@ -1819,9 +1831,12 @@ namespace DownloadManager
                                                 cancelButton.Text = "Close";
                                                 openButton.Enabled = true;
                                                 pauseButton.Enabled = false;
-                                                progressBar1.Value = 100;
-                                                progressBar1.Style = ProgressBarStyle.Blocks;
-                                                progressBar1.MarqueeAnim = false;
+                                                progressBar1.Visible = false;
+                                                progressBar2.Visible = false;
+                                                totalProgressBar.Visible = true;
+                                                totalProgressBar.Value = 100;
+                                                totalProgressBar.Style = ProgressBarStyle.Blocks;
+                                                totalProgressBar.MarqueeAnim = false;
                                                 if (checkBox2.Checked == true)
                                                 {
 
@@ -1835,10 +1850,13 @@ namespace DownloadManager
                                         {
                                             Invoke(new MethodInvoker(delegate
                                             {
-                                                progressBar1.Style = ProgressBarStyle.Blocks;
-                                                progressBar1.MarqueeAnim = false;
-                                                progressBar1.Value = 100;
-                                                progressBar1.State = ProgressBarState.Error;
+                                                progressBar1.Visible = false;
+                                                progressBar2.Visible = false;
+                                                totalProgressBar.Visible = true;
+                                                totalProgressBar.Style = ProgressBarStyle.Blocks;
+                                                totalProgressBar.MarqueeAnim = false;
+                                                totalProgressBar.Value = 100;
+                                                totalProgressBar.State = ProgressBarState.Error;
                                             }));
                                             Log("Failed to verify file. The file will be re-downloaded.", Color.Red);
 
@@ -1939,9 +1957,12 @@ namespace DownloadManager
                                                 cancelButton.Text = "Close";
                                                 openButton.Enabled = true;
                                                 pauseButton.Enabled = false;
-                                                progressBar1.Value = 100;
-                                                progressBar1.Style = ProgressBarStyle.Blocks;
-                                                progressBar1.MarqueeAnim = false;
+                                                progressBar1.Visible = false;
+                                                progressBar2.Visible = false;
+                                                totalProgressBar.Visible = true;
+                                                totalProgressBar.Value = 100;
+                                                totalProgressBar.Style = ProgressBarStyle.Blocks;
+                                                totalProgressBar.MarqueeAnim = false;
                                                 if (checkBox2.Checked == true)
                                                 {
 
@@ -1955,10 +1976,13 @@ namespace DownloadManager
                                         {
                                             Invoke(new MethodInvoker(delegate
                                             {
-                                                progressBar1.Style = ProgressBarStyle.Blocks;
-                                                progressBar1.MarqueeAnim = false;
-                                                progressBar1.Value = 100;
-                                                progressBar1.State = ProgressBarState.Error;
+                                                progressBar1.Visible = false;
+                                                progressBar2.Visible = false;
+                                                totalProgressBar.Visible = true;
+                                                totalProgressBar.Style = ProgressBarStyle.Blocks;
+                                                totalProgressBar.MarqueeAnim = false;
+                                                totalProgressBar.Value = 100;
+                                                totalProgressBar.State = ProgressBarState.Error;
                                             }));
                                             Log("Failed to verify file. The file will be re-downloaded.", Color.Red);
 
@@ -2059,9 +2083,12 @@ namespace DownloadManager
                                                 cancelButton.Text = "Close";
                                                 openButton.Enabled = true;
                                                 pauseButton.Enabled = false;
-                                                progressBar1.Value = 100;
-                                                progressBar1.Style = ProgressBarStyle.Blocks;
-                                                progressBar1.MarqueeAnim = false;
+                                                progressBar1.Visible = false;
+                                                progressBar2.Visible = false;
+                                                totalProgressBar.Visible = true;
+                                                totalProgressBar.Value = 100;
+                                                totalProgressBar.Style = ProgressBarStyle.Blocks;
+                                                totalProgressBar.MarqueeAnim = false;
                                                 if (checkBox2.Checked == true)
                                                 {
 
@@ -2075,10 +2102,13 @@ namespace DownloadManager
                                         {
                                             Invoke(new MethodInvoker(delegate
                                             {
-                                                progressBar1.Style = ProgressBarStyle.Blocks;
-                                                progressBar1.MarqueeAnim = false;
-                                                progressBar1.Value = 100;
-                                                progressBar1.State = ProgressBarState.Error;
+                                                progressBar1.Visible = false;
+                                                progressBar2.Visible = false;
+                                                totalProgressBar.Visible = true;
+                                                totalProgressBar.Style = ProgressBarStyle.Blocks;
+                                                totalProgressBar.MarqueeAnim = false;
+                                                totalProgressBar.Value = 100;
+                                                totalProgressBar.State = ProgressBarState.Error;
                                             }));
                                             Log("Failed to verify file. The file will be re-downloaded.", Color.Red);
 
@@ -2179,9 +2209,12 @@ namespace DownloadManager
                                                 cancelButton.Text = "Close";
                                                 openButton.Enabled = true;
                                                 pauseButton.Enabled = false;
-                                                progressBar1.Value = 100;
-                                                progressBar1.Style = ProgressBarStyle.Blocks;
-                                                progressBar1.MarqueeAnim = false;
+                                                progressBar1.Visible = false;
+                                                progressBar2.Visible = false;
+                                                totalProgressBar.Visible = true;
+                                                totalProgressBar.Value = 100;
+                                                totalProgressBar.Style = ProgressBarStyle.Blocks;
+                                                totalProgressBar.MarqueeAnim = false;
                                                 if (checkBox2.Checked == true)
                                                 {
 
@@ -2195,10 +2228,13 @@ namespace DownloadManager
                                         {
                                             Invoke(new MethodInvoker(delegate
                                             {
-                                                progressBar1.Style = ProgressBarStyle.Blocks;
-                                                progressBar1.MarqueeAnim = false;
-                                                progressBar1.Value = 100;
-                                                progressBar1.State = ProgressBarState.Error;
+                                                progressBar1.Visible = false;
+                                                progressBar2.Visible = false;
+                                                totalProgressBar.Visible = true;
+                                                totalProgressBar.Style = ProgressBarStyle.Blocks;
+                                                totalProgressBar.MarqueeAnim = false;
+                                                totalProgressBar.Value = 100;
+                                                totalProgressBar.State = ProgressBarState.Error;
                                             }));
                                             Log("Failed to verify file. The file will be re-downloaded.", Color.Red);
 
@@ -2301,9 +2337,12 @@ namespace DownloadManager
                                                 cancelButton.Text = "Close";
                                                 openButton.Enabled = true;
                                                 pauseButton.Enabled = false;
-                                                progressBar1.Value = 100;
-                                                progressBar1.Style = ProgressBarStyle.Blocks;
-                                                progressBar1.MarqueeAnim = false;
+                                                progressBar1.Visible = false;
+                                                progressBar2.Visible = false;
+                                                totalProgressBar.Visible = true;
+                                                totalProgressBar.Value = 100;
+                                                totalProgressBar.Style = ProgressBarStyle.Blocks;
+                                                totalProgressBar.MarqueeAnim = false;
                                                 if (checkBox2.Checked == true)
                                                 {
 
@@ -2317,10 +2356,13 @@ namespace DownloadManager
                                         {
                                             Invoke(new MethodInvoker(delegate
                                             {
-                                                progressBar1.Style = ProgressBarStyle.Blocks;
-                                                progressBar1.MarqueeAnim = false;
-                                                progressBar1.Value = 100;
-                                                progressBar1.State = ProgressBarState.Error;
+                                                progressBar1.Visible = false;
+                                                progressBar2.Visible = false;
+                                                totalProgressBar.Visible = true;
+                                                totalProgressBar.Style = ProgressBarStyle.Blocks;
+                                                totalProgressBar.MarqueeAnim = false;
+                                                totalProgressBar.Value = 100;
+                                                totalProgressBar.State = ProgressBarState.Error;
                                             }));
                                             Log("Failed to verify file. The file will be re-downloaded.", Color.Red);
 
@@ -2368,10 +2410,13 @@ namespace DownloadManager
                                     {
                                         Invoke(new MethodInvoker(delegate
                                         {
-                                            progressBar1.Style = ProgressBarStyle.Blocks;
-                                            progressBar1.MarqueeAnim = false;
-                                            progressBar1.Value = 100;
-                                            progressBar1.State = ProgressBarState.Error;
+                                            progressBar1.Visible = false;
+                                            progressBar2.Visible = false;
+                                            totalProgressBar.Visible = true;
+                                            totalProgressBar.Style = ProgressBarStyle.Blocks;
+                                            totalProgressBar.MarqueeAnim = false;
+                                            totalProgressBar.Value = 100;
+                                            totalProgressBar.State = ProgressBarState.Error;
                                         }));
                                         Log("Invalid hash type '" + hashType + "'. The file could not be verified.", Color.Red);
 
@@ -2441,9 +2486,12 @@ namespace DownloadManager
                                     cancelButton.Text = "Close";
                                     openButton.Enabled = true;
                                     pauseButton.Enabled = false;
-                                    progressBar1.Value = 100;
-                                    progressBar1.Style = ProgressBarStyle.Blocks;
-                                    progressBar1.MarqueeAnim = false;
+                                    progressBar1.Visible = false;
+                                    progressBar2.Visible = false;
+                                    totalProgressBar.Visible = true;
+                                    totalProgressBar.Value = 100;
+                                    totalProgressBar.Style = ProgressBarStyle.Blocks;
+                                    totalProgressBar.MarqueeAnim = false;
                                     if (checkBox2.Checked == true)
                                     {
 
@@ -2458,10 +2506,13 @@ namespace DownloadManager
                         {
                             Invoke(new MethodInvoker(delegate
                             {
-                                progressBar1.Style = ProgressBarStyle.Blocks;
-                                progressBar1.MarqueeAnim = false;
-                                progressBar1.Value = 100;
-                                progressBar1.State = ProgressBarState.Error;
+                                progressBar1.Visible = false;
+                                progressBar2.Visible = false;
+                                totalProgressBar.Visible = true;
+                                totalProgressBar.Style = ProgressBarStyle.Blocks;
+                                totalProgressBar.MarqueeAnim = false;
+                                totalProgressBar.Value = 100;
+                                totalProgressBar.State = ProgressBarState.Error;
                             }));
 
                             Log("Download failed.", Color.Red);
@@ -2477,7 +2528,6 @@ namespace DownloadManager
                             {
                                 downloading = false;
                                 DownloadForm.downloadsAmount -= 1;
-                                progressBar1.Value = 0;
 
                                 cancellationToken.Cancel();
 
@@ -2491,10 +2541,13 @@ namespace DownloadManager
                 {
                     Invoke(new MethodInvoker(delegate
                     {
-                        progressBar1.Style = ProgressBarStyle.Blocks;
-                        progressBar1.MarqueeAnim = false;
-                        progressBar1.Value = 100;
-                        progressBar1.State = ProgressBarState.Error;
+                        progressBar1.Visible = false;
+                        progressBar2.Visible = false;
+                        totalProgressBar.Visible = true;
+                        totalProgressBar.Style = ProgressBarStyle.Blocks;
+                        totalProgressBar.MarqueeAnim = false;
+                        totalProgressBar.Value = 100;
+                        totalProgressBar.State = ProgressBarState.Error;
                         downloading = false;
                         DownloadForm.downloadsAmount -= 1;
 
@@ -2705,6 +2758,8 @@ namespace DownloadManager
 
                     cancellationToken.Cancel();
                     progressBar1.State = ProgressBarState.Warning;
+                    progressBar2.State = ProgressBarState.Warning;
+                    totalProgressBar.State = ProgressBarState.Warning;
                 }
                 else
                 {
@@ -2721,6 +2776,8 @@ namespace DownloadManager
                 cancellationToken = new CancellationTokenSource();
 
                 progressBar1.State = ProgressBarState.Normal;
+                progressBar2.State = ProgressBarState.Normal;
+                totalProgressBar.State = ProgressBarState.Normal;
 
                 try
                 {
@@ -2746,10 +2803,13 @@ namespace DownloadManager
 
                     Invoke(new MethodInvoker(delegate
                     {
-                        progressBar1.Style = ProgressBarStyle.Blocks;
-                        progressBar1.MarqueeAnim = false;
-                        progressBar1.Value = 100;
-                        progressBar1.State = ProgressBarState.Error;
+                        progressBar1.Visible = false;
+                        progressBar2.Visible = false;
+                        totalProgressBar.Visible = true;
+                        totalProgressBar.Style = ProgressBarStyle.Blocks;
+                        totalProgressBar.MarqueeAnim = false;
+                        totalProgressBar.Value = 100;
+                        totalProgressBar.State = ProgressBarState.Error;
                     }));
 
                     Log(ex.Message, Color.Red);

--- a/DownloadProgress.cs
+++ b/DownloadProgress.cs
@@ -1201,7 +1201,7 @@ namespace DownloadManager
             }
         }
 
-        private static void CombineFilesIntoSingleFile(string fileName0, string fileName1, string outputFilePath)
+        private static Task CombineFilesIntoSingleFile(string fileName0, string fileName1, string outputFilePath)
         {
             string[] inputFilePaths = new string[]{
                 fileName0,
@@ -1220,6 +1220,8 @@ namespace DownloadManager
                     Logging.Log($"The file {inputFilePath} has been processed.", Color.White);
                 }
             }
+
+            return Task.CompletedTask;
         }
 
         public async Task DownloadFileAsync(Uri uri, CancellationToken cancellationToken = default, Action<long, long, BetterProgressBar>? progressCallback = null, BetterProgressBar? progressBar = null)
@@ -1355,7 +1357,10 @@ namespace DownloadManager
                         bytesLabel.Text = $"{totalSize} B / {totalSize} B";
                     }));
 
-                    CombineFilesIntoSingleFile(location + fileName + ".download0", location + fileName + ".download1", location + fileName);
+                    await CombineFilesIntoSingleFile(location + fileName + ".download0", location + fileName + ".download1", location + fileName);
+
+                    File.Delete(location + fileName + ".download0");
+                    File.Delete(location + fileName + ".download1");
                 }
 
                 request.Abort();

--- a/DownloadProgress.cs
+++ b/DownloadProgress.cs
@@ -37,8 +37,9 @@ namespace DownloadManager
         public long totalSize = 0;
         public double percentageDone = 0;
 
-        double receivedBytes = 0;
-        double totalBytes = 0;
+        public double receivedBytes = 0;
+        public double totalBytes = 0;
+        public int totalProgress = 0;
 
         public bool cancelled = false;
         public bool forceCancel = false;
@@ -1549,6 +1550,7 @@ namespace DownloadManager
                     await outputStream.WriteAsync(buffer, 0, len).ConfigureAwait(false);
                     totalRead += len;
                     this.Invoke(new MethodInvoker(delegate () { bytesLabel.Text = $"({totalRead} B / ? B)"; }));
+                    receivedBytes = totalRead;
                 }
 
                 await outputStream.FlushAsync().ConfigureAwait(false);

--- a/DownloadProgress.cs
+++ b/DownloadProgress.cs
@@ -1490,48 +1490,6 @@ namespace DownloadManager
 
                 request.Abort();
                 response.Close();
-
-                /*if (progressCallback != null)
-                {
-                    long length = 0;
-                    if (_instance.totalSize == 0)
-                    {
-                        length = response.Content.Headers.ContentLength ?? -1;
-                        _instance.totalSize = length;
-
-                        if (length == -1)
-                        {
-                            _instance.restartNoProgress = true;
-                            _instance.cancellationToken.Cancel();
-                            Logging.Log("Server failed to provide content length. Progress report will not be available.", Color.Orange);
-                            new ToastContentBuilder()
-                                                .AddText($"The remote server failed to provide size of {_instance.fileName}. Progress reports will not be available.")
-                                                .Show();
-                            _instance.progressBar1.Style = ProgressBarStyle.Marquee;
-                            _instance.progressBar1.MarqueeAnim = true;
-                            return;
-                        }
-                    }
-                    else
-                    {
-                        length = _instance.totalSize;
-                    }
-                    await using Stream stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
-                    byte[] buffer = new byte[4096];
-                    int read;
-                    long totalRead = 0;
-                    while ((read = await stream.ReadAsync(buffer, 0, buffer.Length, cancellationToken).ConfigureAwait(false)) > 0)
-                    {
-                        await toStream.WriteAsync(buffer, 0, read, cancellationToken).ConfigureAwait(false);
-                        totalRead += read;
-                        progressCallback(totalRead, length);
-                    }
-                    Debug.Assert(totalRead == length || length == -1);
-                }
-                else
-                {
-                    await response.Content.CopyToAsync(toStream).ConfigureAwait(false);
-                }*/
             }
         }
 
@@ -2303,8 +2261,6 @@ namespace DownloadManager
                                             result.Append(myHash[i].ToString(false ? "X2" : "x2"));
                                         }
 
-                                        //Log("Provided Hash: " + hash + Environment.NewLine + "Generated Hash: " + result.ToString(), Color.White);
-
                                         if (result.ToString() == hash)
                                         {
                                             Log("File verification OK.", Color.White);
@@ -2875,9 +2831,6 @@ namespace DownloadManager
             {
                 bytesLabel.Text = $"({receivedBytes} B / ? B)";
             }
-            /*bytesLabel.Text = $"({receivedBytes} B / {totalBytes} B)";
-            this.Text = $"Downloading {fileName}... ({string.Format("{0:0.##}", percentageDone)}%)";
-            progressLabel.Text = $"{percentageDone}%";*/
         }
     }
 }

--- a/DownloadProgress.cs
+++ b/DownloadProgress.cs
@@ -494,7 +494,7 @@ namespace DownloadManager
                 this.Invoke(new MethodInvoker(delegate ()
                 {
                     bytesLabel.Visible = false;
-                    label3.Text = "Downloading YouTube videos does not support progress callbacks.";
+                    progressLabel.Text = "Downloading YouTube videos does not support progress callbacks.";
                     hashLabel.Text = "Downloading YouTube videos does not support file verification.";
                     pauseButton.Enabled = false;
 

--- a/DownloadProgress.cs
+++ b/DownloadProgress.cs
@@ -1354,7 +1354,7 @@ namespace DownloadManager
                         progressBar2.Value = 100;
                         this.Text = $"Downloading {fileName}... (100%)";
                         progressLabel.Text = $"100%";
-                        bytesLabel.Text = $"{totalSize} B / {totalSize} B";
+                        bytesLabel.Text = $"({totalSize} B / {totalSize} B)";
                     }));
 
                     await CombineFilesIntoSingleFile(location + fileName + ".download0", location + fileName + ".download1", location + fileName);

--- a/DownloadProgress.cs
+++ b/DownloadProgress.cs
@@ -1,4 +1,6 @@
-﻿using DownloadManager.NativeMethods;
+﻿// https://stackoverflow.com/questions/44441784/how-do-i-download-a-file-in-segments-in-c
+
+using DownloadManager.NativeMethods;
 using Microsoft.Toolkit.Uwp.Notifications;
 using System.Diagnostics;
 using System.Media;

--- a/DownloadProgress.cs
+++ b/DownloadProgress.cs
@@ -1,6 +1,4 @@
-﻿// https://stackoverflow.com/questions/44441784/how-do-i-download-a-file-in-segments-in-c
-
-using DownloadManager.Download;
+﻿using DownloadManager.Download;
 using DownloadManager.NativeMethods;
 using Microsoft.Toolkit.Uwp.Notifications;
 using System.Diagnostics;
@@ -139,18 +137,21 @@ namespace DownloadManager
                 urlLabel.Text = $"{listMetadata.Title.Replace(":", "_").Replace("<", "_").Replace(">", "_").Replace('"', '_').Replace("/", "_").Replace(@"\", "_").Replace("|", "_").Replace("?", "_").Replace("*", "_") + @"\"} from youtube.com";
                 hashLabel.Text = "Downloading YouTube playlists does not support file verification.";
                 bytesLabel.Visible = false;
-                label3.Visible = false;
-                progressBar1.Style = ProgressBarStyle.Marquee;
-                progressBar1.Visible = true;
+                progressLabel.Visible = false;
+                totalProgressBar.Visible = true;
+                totalProgressBar.Style = ProgressBarStyle.Marquee;
+                totalProgressBar.Visible = true;
+                progressBar1.Visible = false;
+                progressBar2.Visible = false;
 
                 if (downloadType == DownloadType.YoutubeVideo || downloadType == DownloadType.YoutubePlaylist)
                 {
                     if (DownloadForm.ytDownloading == true)
                     {
-                        progressBar1.Style = ProgressBarStyle.Blocks;
-                        progressBar1.State = ProgressBarState.Error;
-                        progressBar1.ShowText = false;
-                        progressBar1.Value = 100;
+                        totalProgressBar.Style = ProgressBarStyle.Blocks;
+                        totalProgressBar.State = ProgressBarState.Error;
+                        totalProgressBar.ShowText = false;
+                        totalProgressBar.Value = 100;
                         DarkMessageBox msg = new("Another YouTube download is currently in progress.\nPlease wait until the download is complete before attempting to download another.", "YouTube Download Warning", MessageBoxButtons.OK, MessageBoxIcon.Warning);
                         msg.ShowDialog();
                         downloading = false;
@@ -193,10 +194,10 @@ namespace DownloadManager
                         // Update progressbar with video count 
                         this.Invoke(new MethodInvoker(delegate ()
                         {
-                            progressBar1.Maximum = videoCount;
-                            progressBar1.Minimum = 0;
-                            progressBar1.Value = 0;
-                            progressBar1.Style = ProgressBarStyle.Blocks;
+                            totalProgressBar.Maximum = videoCount;
+                            totalProgressBar.Minimum = 0;
+                            totalProgressBar.Value = 0;
+                            totalProgressBar.Style = ProgressBarStyle.Blocks;
                         }));
 
                         // Download each video
@@ -243,7 +244,8 @@ namespace DownloadManager
 
                             this.Invoke(new MethodInvoker(delegate ()
                             {
-                                progressBar1.Value += 1;
+                                totalProgressBar.Value += 1;
+
                             }));
                         }
 
@@ -299,10 +301,10 @@ namespace DownloadManager
                         // Update progressbar with video count 
                         this.Invoke(new MethodInvoker(delegate ()
                         {
-                            progressBar1.Maximum = videoCount;
-                            progressBar1.Minimum = 0;
-                            progressBar1.Value = 0;
-                            progressBar1.Style = ProgressBarStyle.Blocks;
+                            totalProgressBar.Maximum = videoCount;
+                            totalProgressBar.Minimum = 0;
+                            totalProgressBar.Value = 0;
+                            totalProgressBar.Style = ProgressBarStyle.Blocks;
                         }));
 
                         // Download each video
@@ -326,7 +328,7 @@ namespace DownloadManager
 
                             this.Invoke(new MethodInvoker(delegate ()
                             {
-                                progressBar1.Value += 1;
+                                totalProgressBar.Value += 1;
                             }));
                         }
 
@@ -383,10 +385,10 @@ namespace DownloadManager
                         // Update progressbar with video count 
                         this.Invoke(new MethodInvoker(delegate ()
                         {
-                            progressBar1.Maximum = videoCount;
-                            progressBar1.Minimum = 0;
-                            progressBar1.Value = 0;
-                            progressBar1.Style = ProgressBarStyle.Blocks;
+                            totalProgressBar.Maximum = videoCount;
+                            totalProgressBar.Minimum = 0;
+                            totalProgressBar.Value = 0;
+                            totalProgressBar.Style = ProgressBarStyle.Blocks;
                         }));
 
                         // Download each video
@@ -410,7 +412,7 @@ namespace DownloadManager
 
                             this.Invoke(new MethodInvoker(delegate ()
                             {
-                                progressBar1.Value += 1;
+                                totalProgressBar.Value += 1;
                             }));
                         }
 
@@ -493,19 +495,26 @@ namespace DownloadManager
 
                 this.Invoke(new MethodInvoker(delegate ()
                 {
+                    updateDisplayTimer.Stop();
                     bytesLabel.Visible = false;
                     progressLabel.Text = "Downloading YouTube videos does not support progress callbacks.";
                     hashLabel.Text = "Downloading YouTube videos does not support file verification.";
                     pauseButton.Enabled = false;
+                    totalProgressBar.Visible = true;
+                    totalProgressBar.Style = ProgressBarStyle.Marquee;
+                    totalProgressBar.MarqueeAnim = true;
+                    totalProgressBar.ShowText = false;
+                    progressBar1.Visible = false;
+                    progressBar2.Visible = false;
 
                     if (downloadType == DownloadType.YoutubeVideo || downloadType == DownloadType.YoutubePlaylist)
                     {
                         if (DownloadForm.ytDownloading == true)
                         {
-                            progressBar1.Style = ProgressBarStyle.Blocks;
-                            progressBar1.State = ProgressBarState.Error;
-                            progressBar1.ShowText = false;
-                            progressBar1.Value = 100;
+                            totalProgressBar.Style = ProgressBarStyle.Blocks;
+                            totalProgressBar.State = ProgressBarState.Error;
+                            totalProgressBar.ShowText = false;
+                            totalProgressBar.Value = 100;
                             DarkMessageBox msg = new("Another YouTube download is currently in progress.\nPlease wait until the download is complete before attempting to download another.", "YouTube Download Warning", MessageBoxButtons.OK, MessageBoxIcon.Warning);
                             msg.ShowDialog();
                             downloading = false;
@@ -619,9 +628,9 @@ namespace DownloadManager
                         cancelButton.Text = "Close";
                         openButton.Enabled = true;
                         pauseButton.Enabled = false;
-                        progressBar1.Value = 100;
-                        progressBar1.Style = ProgressBarStyle.Blocks;
-                        progressBar1.MarqueeAnim = false;
+                        totalProgressBar.Value = 100;
+                        totalProgressBar.Style = ProgressBarStyle.Blocks;
+                        totalProgressBar.MarqueeAnim = false;
                         if (checkBox2.Checked == true)
                         {
 
@@ -723,9 +732,9 @@ namespace DownloadManager
                         cancelButton.Text = "Close";
                         openButton.Enabled = true;
                         pauseButton.Enabled = false;
-                        progressBar1.Value = 100;
-                        progressBar1.Style = ProgressBarStyle.Blocks;
-                        progressBar1.MarqueeAnim = false;
+                        totalProgressBar.Value = 100;
+                        totalProgressBar.Style = ProgressBarStyle.Blocks;
+                        totalProgressBar.MarqueeAnim = false;
                         if (checkBox2.Checked == true)
                         {
 
@@ -855,9 +864,9 @@ namespace DownloadManager
                         cancelButton.Text = "Close";
                         openButton.Enabled = true;
                         pauseButton.Enabled = false;
-                        progressBar1.Value = 100;
-                        progressBar1.Style = ProgressBarStyle.Blocks;
-                        progressBar1.MarqueeAnim = false;
+                        totalProgressBar.Value = 100;
+                        totalProgressBar.Style = ProgressBarStyle.Blocks;
+                        totalProgressBar.MarqueeAnim = false;
                         if (checkBox2.Checked == true)
                         {
 
@@ -1283,6 +1292,7 @@ namespace DownloadManager
                 long contentLength = response.ContentLength;
 
                 totalSize = contentLength;
+                fileSize = contentLength.ToString();
 
                 request = (HttpWebRequest)WebRequest.Create(uri);
                 request.AddRange(0, contentLength / 2);
@@ -2594,7 +2604,7 @@ namespace DownloadManager
             progressUpdater.UpdateUI();
             /*bytesLabel.Text = $"({receivedBytes} B / {totalBytes} B)";
             this.Text = $"Downloading {fileName}... ({string.Format("{0:0.##}", percentageDone)}%)";
-            label3.Text = $"{percentageDone}%";*/
+            progressLabel.Text = $"{percentageDone}%";*/
         }
     }
 }

--- a/DownloadProgress.cs
+++ b/DownloadProgress.cs
@@ -1429,7 +1429,6 @@ namespace DownloadManager
                     {
                         // The server failed to report content length so does not support range requests and we cannot report progress
                         // Dispose of multiple progress bars updater
-                        updateDisplayTimer.Stop();
                         progressUpdater = null;
 
                         this.Invoke(new MethodInvoker(delegate ()
@@ -1569,7 +1568,6 @@ namespace DownloadManager
                 {
                     await outputStream.WriteAsync(buffer, 0, len).ConfigureAwait(false);
                     totalRead += len;
-                    this.Invoke(new MethodInvoker(delegate () { bytesLabel.Text = $"({totalRead} B / ? B)"; }));
                     receivedBytes = totalRead;
                 }
 

--- a/DownloadProgress.cs
+++ b/DownloadProgress.cs
@@ -1330,7 +1330,20 @@ namespace DownloadManager
                     DownloadSegment segment1 = new DownloadSegment();
                     await segment1.DownloadFileSegment(DownloadSegment.DownloadSegmentID.Segment1, this, streamResponse, fileStream1, contentLength / 2 + 1, contentLength, location + fileName + ".download1", progressBar2, cancellationToken, progressUpdater);
 
-                    // TODO: wait for both segments to finish before continuing
+                    while (segment0.isDownloading || segment1.isDownloading)
+                    {
+                        Application.DoEvents();
+                        await Task.Delay(100);
+                    }
+
+                    this.Invoke(new MethodInvoker(delegate
+                    {
+                        updateDisplayTimer.Stop();
+                        progressBar2.Value = 100;
+                        this.Text = $"Downloading {fileName}... (100%)";
+                        progressLabel.Text = $"100%";
+                        bytesLabel.Text = $"{totalSize} B / {totalSize} B";
+                    }));
 
                     CombineFilesIntoSingleFile(location + fileName + ".download0", location + fileName + ".download1", location + fileName);
                 }


### PR DESCRIPTION
## Description of changes
Rework the download system to download the files in multiple segments instead of 1 large file to increase download speed.

## Task List:
- [x] Implement basic download segment system
- [x] Implement progress callback
- [x] Implement cancellation
- [x] Implement progress callback to `CurrentDownloads`
- [x] Implement the use of `totalProgressBar` instead of segment progress bars for showing errors
- [x] Code cleanup