### PR TITLE
Make a new view for the CurrentDownloads window

### DIFF
--- a/App.config
+++ b/App.config
@@ -54,6 +54,9 @@
             <setting name="maxServerFailureCount" serializeAs="String">
                 <value>5</value>
             </setting>
+            <setting name="currentDownloadsSize" serializeAs="String">
+                <value>495, 519</value>
+            </setting>
         </DownloadManager.Settings>
         <Settings1>
             <setting name="defaultDownload" serializeAs="String">

--- a/ColumnEditor.Designer.cs
+++ b/ColumnEditor.Designer.cs
@@ -37,13 +37,14 @@
             showButton = new Button();
             hideButton = new Button();
             doneButton = new Button();
+            resetButton = new Button();
             SuspendLayout();
             // 
             // descLabel
             // 
             descLabel.Location = new Point(12, 9);
             descLabel.Name = "descLabel";
-            descLabel.Size = new Size(540, 55);
+            descLabel.Size = new Size(436, 55);
             descLabel.TabIndex = 0;
             descLabel.Text = "Use this dialogue to select all colunms to show or hide.\r\nTo show columns move them to the 'Show' side.\r\nTo hide columns move them to the 'Hide' side.";
             // 
@@ -128,11 +129,27 @@
             doneButton.UseVisualStyleBackColor = false;
             doneButton.Click += doneButton_Click;
             // 
+            // resetButton
+            // 
+            resetButton.BackColor = Color.Black;
+            resetButton.FlatAppearance.MouseDownBackColor = Color.Gray;
+            resetButton.FlatStyle = FlatStyle.Flat;
+            resetButton.ForeColor = Color.White;
+            resetButton.Location = new Point(464, 12);
+            resetButton.Margin = new Padding(4, 3, 4, 3);
+            resetButton.Name = "resetButton";
+            resetButton.Size = new Size(88, 29);
+            resetButton.TabIndex = 8;
+            resetButton.Text = "Reset";
+            resetButton.UseVisualStyleBackColor = false;
+            resetButton.Click += resetButton_Click;
+            // 
             // ColumnEditor
             // 
             AutoScaleDimensions = new SizeF(7F, 16F);
             AutoScaleMode = AutoScaleMode.Font;
             ClientSize = new Size(565, 361);
+            Controls.Add(resetButton);
             Controls.Add(doneButton);
             Controls.Add(hideButton);
             Controls.Add(showButton);
@@ -161,5 +178,6 @@
         private Button showButton;
         private Button hideButton;
         private Button doneButton;
+        private Button resetButton;
     }
 }

--- a/ColumnEditor.Designer.cs
+++ b/ColumnEditor.Designer.cs
@@ -1,0 +1,165 @@
+﻿namespace DownloadManager
+{
+    partial class ColumnEditor
+    {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(ColumnEditor));
+            descLabel = new Label();
+            showLabel = new Label();
+            showList = new ListBox();
+            hideList = new ListBox();
+            hideLabel = new Label();
+            showButton = new Button();
+            hideButton = new Button();
+            doneButton = new Button();
+            SuspendLayout();
+            // 
+            // descLabel
+            // 
+            descLabel.Location = new Point(12, 9);
+            descLabel.Name = "descLabel";
+            descLabel.Size = new Size(540, 55);
+            descLabel.TabIndex = 0;
+            descLabel.Text = "Use this dialogue to select all colunms to show or hide.\r\nTo show columns move them to the 'Show' side.\r\nTo hide columns move them to the 'Hide' side.";
+            // 
+            // showLabel
+            // 
+            showLabel.AutoSize = true;
+            showLabel.Location = new Point(12, 64);
+            showLabel.Name = "showLabel";
+            showLabel.Size = new Size(37, 16);
+            showLabel.TabIndex = 1;
+            showLabel.Text = "Show";
+            // 
+            // showList
+            // 
+            showList.FormattingEnabled = true;
+            showList.ItemHeight = 16;
+            showList.Location = new Point(12, 83);
+            showList.Name = "showList";
+            showList.Size = new Size(215, 260);
+            showList.TabIndex = 2;
+            // 
+            // hideList
+            // 
+            hideList.FormattingEnabled = true;
+            hideList.ItemHeight = 16;
+            hideList.Location = new Point(233, 83);
+            hideList.Name = "hideList";
+            hideList.Size = new Size(215, 260);
+            hideList.TabIndex = 4;
+            // 
+            // hideLabel
+            // 
+            hideLabel.AutoSize = true;
+            hideLabel.Location = new Point(233, 64);
+            hideLabel.Name = "hideLabel";
+            hideLabel.Size = new Size(33, 16);
+            hideLabel.TabIndex = 3;
+            hideLabel.Text = "Hide";
+            // 
+            // showButton
+            // 
+            showButton.BackColor = Color.Black;
+            showButton.FlatAppearance.MouseDownBackColor = Color.Gray;
+            showButton.FlatStyle = FlatStyle.Flat;
+            showButton.ForeColor = Color.White;
+            showButton.Location = new Point(464, 83);
+            showButton.Margin = new Padding(4, 3, 4, 3);
+            showButton.Name = "showButton";
+            showButton.Size = new Size(88, 29);
+            showButton.TabIndex = 5;
+            showButton.Text = "<< Show";
+            showButton.UseVisualStyleBackColor = false;
+            showButton.Click += showButton_Click;
+            // 
+            // hideButton
+            // 
+            hideButton.BackColor = Color.Black;
+            hideButton.FlatAppearance.MouseDownBackColor = Color.Gray;
+            hideButton.FlatStyle = FlatStyle.Flat;
+            hideButton.ForeColor = Color.White;
+            hideButton.Location = new Point(464, 118);
+            hideButton.Margin = new Padding(4, 3, 4, 3);
+            hideButton.Name = "hideButton";
+            hideButton.Size = new Size(88, 29);
+            hideButton.TabIndex = 6;
+            hideButton.Text = "Hide >>";
+            hideButton.UseVisualStyleBackColor = false;
+            hideButton.Click += hideButton_Click;
+            // 
+            // doneButton
+            // 
+            doneButton.BackColor = Color.Black;
+            doneButton.FlatAppearance.MouseDownBackColor = Color.Gray;
+            doneButton.FlatStyle = FlatStyle.Flat;
+            doneButton.ForeColor = Color.White;
+            doneButton.Location = new Point(464, 314);
+            doneButton.Margin = new Padding(4, 3, 4, 3);
+            doneButton.Name = "doneButton";
+            doneButton.Size = new Size(88, 29);
+            doneButton.TabIndex = 7;
+            doneButton.Text = "Done";
+            doneButton.UseVisualStyleBackColor = false;
+            doneButton.Click += doneButton_Click;
+            // 
+            // ColumnEditor
+            // 
+            AutoScaleDimensions = new SizeF(7F, 16F);
+            AutoScaleMode = AutoScaleMode.Font;
+            ClientSize = new Size(565, 361);
+            Controls.Add(doneButton);
+            Controls.Add(hideButton);
+            Controls.Add(showButton);
+            Controls.Add(hideList);
+            Controls.Add(hideLabel);
+            Controls.Add(showList);
+            Controls.Add(showLabel);
+            Controls.Add(descLabel);
+            FormBorderStyle = FormBorderStyle.FixedDialog;
+            Icon = (Icon)resources.GetObject("$this.Icon");
+            MaximizeBox = false;
+            MinimizeBox = false;
+            Name = "ColumnEditor";
+            Text = "Column Editor";
+            ResumeLayout(false);
+            PerformLayout();
+        }
+
+        #endregion
+
+        private Label descLabel;
+        private Label showLabel;
+        private ListBox showList;
+        private ListBox hideList;
+        private Label hideLabel;
+        private Button showButton;
+        private Button hideButton;
+        private Button doneButton;
+    }
+}

--- a/ColumnEditor.cs
+++ b/ColumnEditor.cs
@@ -1,0 +1,175 @@
+﻿using DownloadManager.NativeMethods;
+using static DownloadManager.CurrentDownloads;
+
+namespace DownloadManager
+{
+    public partial class ColumnEditor : Form
+    {
+        CurrentDownloads downloads;
+
+        public ColumnEditor(CurrentDownloads downloads)
+        {
+            InitializeComponent();
+
+            this.downloads = downloads;
+
+            DesktopWindowManager.SetImmersiveDarkMode(this.Handle, true);
+            DesktopWindowManager.EnableMicaIfSupported(this.Handle);
+            DesktopWindowManager.ExtendFrameIntoClientArea(this.Handle);
+
+            foreach (string item in Settings.Default.currentDownloadsShownColumns)
+            {
+                Application.DoEvents();
+                switch (item)
+                {
+                    case "0":
+                        showList.Items.Add("File Name");
+                        break;
+                    case "1":
+                        showList.Items.Add("Progress");
+                        break;
+                    case "2":
+                        showList.Items.Add("URL");
+                        break;
+                    case "3":
+                        showList.Items.Add("Size");
+                        break;
+                    default:
+                        // Invalid column
+                        Logging.Log("Found invalid column while creating list of shown columns!", Color.Red);
+                        showList.Items.Add("<unknown>");
+                        break;
+                }
+            }
+
+            foreach (string item in Settings.Default.currentDownloadsHiddenColumns)
+            {
+                Application.DoEvents();
+
+                if (Settings.Default.currentDownloadsShownColumns.Contains(item))
+                {
+                    Logging.Log("Duplicate column found in shown columns while making list of hidden columns. The item will be removed.", Color.Orange);
+                    Settings.Default.currentDownloadsHiddenColumns.Remove(item);
+                    Settings.Default.Save();
+                    break;
+                }
+
+                switch (item)
+                {
+                    case "0":
+                        hideList.Items.Add("File Name");
+                        break;
+                    case "1":
+                        hideList.Items.Add("Progress");
+                        break;
+                    case "2":
+                        hideList.Items.Add("URL");
+                        break;
+                    case "3":
+                        hideList.Items.Add("Size");
+                        break;
+                    default:
+                        // Invalid column
+                        Logging.Log("Found invalid column while creating list of shown columns!", Color.Red);
+                        hideList.Items.Add("<unknown>");
+                        break;
+                }
+            }
+        }
+
+        private void doneButton_Click(object sender, EventArgs e)
+        {
+            // Create list of shown columns
+            Settings.Default.currentDownloadsShownColumns.Clear();
+
+            List<Column> shownColumns = new List<Column>();
+            foreach (string item in showList.Items)
+            {
+                switch (item)
+                {
+                    case "File Name":
+                        shownColumns.Add(Column.fileName);
+                        Settings.Default.currentDownloadsShownColumns.Add(((int)Column.fileName).ToString());
+                        break;
+                    case "Progress":
+                        shownColumns.Add(Column.progress);
+                        Settings.Default.currentDownloadsShownColumns.Add(((int)Column.progress).ToString());
+                        break;
+                    case "URL":
+                        shownColumns.Add(Column.url);
+                        Settings.Default.currentDownloadsShownColumns.Add(((int)Column.url).ToString());
+                        break;
+                    case "Size":
+                        shownColumns.Add(Column.size);
+                        Settings.Default.currentDownloadsShownColumns.Add(((int)Column.size).ToString());
+                        break;
+                    default:
+                        // Invalid column
+                        Logging.Log("Found invalid column while creating list of shown columns! The item will be ignored.", Color.Orange);
+                        break;
+                }
+            }
+
+            Settings.Default.currentDownloadsHiddenColumns.Clear();
+
+            List<Column> hiddenColumns = new List<Column>();
+            foreach (string item in hideList.Items)
+            {
+                switch (item)
+                {
+                    case "File Name":
+                        hiddenColumns.Add(Column.fileName);
+                        Settings.Default.currentDownloadsHiddenColumns.Add(((int)Column.fileName).ToString());
+                        break;
+                    case "Progress":
+                        hiddenColumns.Add(Column.progress);
+                        Settings.Default.currentDownloadsHiddenColumns.Add(((int)Column.progress).ToString());
+                        break;
+                    case "URL":
+                        hiddenColumns.Add(Column.url);
+                        Settings.Default.currentDownloadsHiddenColumns.Add(((int)Column.url).ToString());
+                        break;
+                    case "Size":
+                        hiddenColumns.Add(Column.size);
+                        Settings.Default.currentDownloadsHiddenColumns.Add(((int)Column.size).ToString());
+                        break;
+                    default:
+                        // Invalid column
+                        Logging.Log("Found invalid column while creating list of hidden columns! The item will be ignored.", Color.Orange);
+                        break;
+                }
+            }
+
+            Settings.Default.Save();
+            downloads.HideColumns(hiddenColumns, shownColumns);
+
+            this.Close();
+        }
+
+        private void showButton_Click(object sender, EventArgs e)
+        {
+            // Move item to shown list
+            if (hideList.SelectedIndex == -1)
+            {
+                // Do nothing
+                return;
+            }
+
+            showList.Items.Add(hideList.Items[hideList.SelectedIndex]);
+            hideList.Items.RemoveAt(hideList.SelectedIndex);
+        }
+
+        private void hideButton_Click(object sender, EventArgs e)
+        {
+            // Hide item to hide list
+            if (showList.SelectedIndex == -1)
+            {
+                // Do nothing
+                return;
+            }
+
+            hideList.Items.Add(showList.Items[showList.SelectedIndex]);
+            showList.Items.RemoveAt(showList.SelectedIndex);
+        }
+    }
+}

--- a/ColumnEditor.cs
+++ b/ColumnEditor.cs
@@ -29,12 +29,15 @@ namespace DownloadManager
                         showList.Items.Add("Progress");
                         break;
                     case "2":
-                        showList.Items.Add("URL");
+                        showList.Items.Add("Speed");
                         break;
                     case "3":
-                        showList.Items.Add("Received");
+                        showList.Items.Add("URL");
                         break;
                     case "4":
+                        showList.Items.Add("Received");
+                        break;
+                    case "5":
                         showList.Items.Add("Size");
                         break;
                     default:
@@ -66,12 +69,15 @@ namespace DownloadManager
                         hideList.Items.Add("Progress");
                         break;
                     case "2":
-                        hideList.Items.Add("URL");
+                        hideList.Items.Add("Speed");
                         break;
                     case "3":
-                        hideList.Items.Add("Received");
+                        hideList.Items.Add("URL");
                         break;
                     case "4":
+                        hideList.Items.Add("Received");
+                        break;
+                    case "5":
                         hideList.Items.Add("Size");
                         break;
                     default:
@@ -100,6 +106,10 @@ namespace DownloadManager
                     case "Progress":
                         shownColumns.Add(Column.progress);
                         Settings.Default.currentDownloadsShownColumns.Add(((int)Column.progress).ToString());
+                        break;
+                    case "Speed":
+                        shownColumns.Add(Column.speed);
+                        Settings.Default.currentDownloadsShownColumns.Add(((int)Column.speed).ToString());
                         break;
                     case "URL":
                         shownColumns.Add(Column.url);
@@ -134,6 +144,10 @@ namespace DownloadManager
                     case "Progress":
                         hiddenColumns.Add(Column.progress);
                         Settings.Default.currentDownloadsHiddenColumns.Add(((int)Column.progress).ToString());
+                        break;
+                    case "Speed":
+                        hiddenColumns.Add(Column.speed);
+                        Settings.Default.currentDownloadsHiddenColumns.Add(((int)Column.speed).ToString());
                         break;
                     case "URL":
                         hiddenColumns.Add(Column.url);
@@ -196,6 +210,9 @@ namespace DownloadManager
                 showList.Items.Clear();
                 hideList.Items.Clear();
 
+                List<Column> shownColumns = new List<Column>();
+                List<Column> hiddenColumns = new List<Column>();
+
                 foreach (string item in Settings.Default.currentDownloadsShownColumns)
                 {
                     Application.DoEvents();
@@ -203,18 +220,27 @@ namespace DownloadManager
                     {
                         case "0":
                             showList.Items.Add("File Name");
+                            shownColumns.Add(Column.fileName);
                             break;
                         case "1":
                             showList.Items.Add("Progress");
+                            shownColumns.Add(Column.progress);
                             break;
                         case "2":
-                            showList.Items.Add("URL");
+                            showList.Items.Add("Speed");
+                            shownColumns.Add(Column.speed);
                             break;
                         case "3":
-                            showList.Items.Add("Received");
+                            showList.Items.Add("URL");
+                            shownColumns.Add(Column.url);
                             break;
                         case "4":
+                            showList.Items.Add("Received");
+                            shownColumns.Add(Column.received);
+                            break;
+                        case "5":
                             showList.Items.Add("Size");
+                            shownColumns.Add(Column.size);
                             break;
                         default:
                             // Invalid column
@@ -240,18 +266,27 @@ namespace DownloadManager
                     {
                         case "0":
                             hideList.Items.Add("File Name");
+                            hiddenColumns.Add(Column.fileName);
                             break;
                         case "1":
                             hideList.Items.Add("Progress");
+                            hiddenColumns.Add(Column.progress);
                             break;
                         case "2":
-                            hideList.Items.Add("URL");
+                            hideList.Items.Add("Speed");
+                            hiddenColumns.Add(Column.speed);
                             break;
                         case "3":
-                            hideList.Items.Add("Received");
+                            hideList.Items.Add("URL");
+                            hiddenColumns.Add(Column.url);
                             break;
                         case "4":
+                            hideList.Items.Add("Received");
+                            hiddenColumns.Add(Column.received);
+                            break;
+                        case "5":
                             hideList.Items.Add("Size");
+                            hiddenColumns.Add(Column.size);
                             break;
                         default:
                             // Invalid column
@@ -261,7 +296,7 @@ namespace DownloadManager
                     }
                 }
 
-                downloads.HideColumns(new List<Column> { Column.received }, new List<Column> { Column.fileName, Column.progress, Column.size, Column.url });
+                downloads.HideColumns(hiddenColumns, shownColumns);
             }
         }
     }

--- a/ColumnEditor.cs
+++ b/ColumnEditor.cs
@@ -32,6 +32,9 @@ namespace DownloadManager
                         showList.Items.Add("URL");
                         break;
                     case "3":
+                        showList.Items.Add("Received");
+                        break;
+                    case "4":
                         showList.Items.Add("Size");
                         break;
                     default:
@@ -66,6 +69,9 @@ namespace DownloadManager
                         hideList.Items.Add("URL");
                         break;
                     case "3":
+                        hideList.Items.Add("Received");
+                        break;
+                    case "4":
                         hideList.Items.Add("Size");
                         break;
                     default:
@@ -99,6 +105,10 @@ namespace DownloadManager
                         shownColumns.Add(Column.url);
                         Settings.Default.currentDownloadsShownColumns.Add(((int)Column.url).ToString());
                         break;
+                    case "Received":
+                        shownColumns.Add(Column.received);
+                        Settings.Default.currentDownloadsShownColumns.Add(((int)Column.received).ToString());
+                        break;
                     case "Size":
                         shownColumns.Add(Column.size);
                         Settings.Default.currentDownloadsShownColumns.Add(((int)Column.size).ToString());
@@ -128,6 +138,10 @@ namespace DownloadManager
                     case "URL":
                         hiddenColumns.Add(Column.url);
                         Settings.Default.currentDownloadsHiddenColumns.Add(((int)Column.url).ToString());
+                        break;
+                    case "Received":
+                        hiddenColumns.Add(Column.received);
+                        Settings.Default.currentDownloadsHiddenColumns.Add(((int)Column.received).ToString());
                         break;
                     case "Size":
                         hiddenColumns.Add(Column.size);
@@ -170,6 +184,85 @@ namespace DownloadManager
 
             hideList.Items.Add(showList.Items[showList.SelectedIndex]);
             showList.Items.RemoveAt(showList.SelectedIndex);
+        }
+
+        private void resetButton_Click(object sender, EventArgs e)
+        {
+            DialogResult result = new DarkMessageBox("Are you sure you want to reset your column preferences?\nThis should only be used if new columns added in an update are not showing or you are experiencing issues with hiding/showing columns.", "Reset Column Preferences?", MessageBoxButtons.YesNo, MessageBoxIcon.Question, false).ShowDialog();
+            if (result == DialogResult.Yes)
+            {
+                DownloadForm._instance.SetupColumnPrefs();
+
+                showList.Items.Clear();
+                hideList.Items.Clear();
+
+                foreach (string item in Settings.Default.currentDownloadsShownColumns)
+                {
+                    Application.DoEvents();
+                    switch (item)
+                    {
+                        case "0":
+                            showList.Items.Add("File Name");
+                            break;
+                        case "1":
+                            showList.Items.Add("Progress");
+                            break;
+                        case "2":
+                            showList.Items.Add("URL");
+                            break;
+                        case "3":
+                            showList.Items.Add("Received");
+                            break;
+                        case "4":
+                            showList.Items.Add("Size");
+                            break;
+                        default:
+                            // Invalid column
+                            Logging.Log("Found invalid column while creating list of shown columns!", Color.Red);
+                            showList.Items.Add("<unknown>");
+                            break;
+                    }
+                }
+
+                foreach (string item in Settings.Default.currentDownloadsHiddenColumns)
+                {
+                    Application.DoEvents();
+
+                    if (Settings.Default.currentDownloadsShownColumns.Contains(item))
+                    {
+                        Logging.Log("Duplicate column found in shown columns while making list of hidden columns. The item will be removed.", Color.Orange);
+                        Settings.Default.currentDownloadsHiddenColumns.Remove(item);
+                        Settings.Default.Save();
+                        break;
+                    }
+
+                    switch (item)
+                    {
+                        case "0":
+                            hideList.Items.Add("File Name");
+                            break;
+                        case "1":
+                            hideList.Items.Add("Progress");
+                            break;
+                        case "2":
+                            hideList.Items.Add("URL");
+                            break;
+                        case "3":
+                            hideList.Items.Add("Received");
+                            break;
+                        case "4":
+                            hideList.Items.Add("Size");
+                            break;
+                        default:
+                            // Invalid column
+                            Logging.Log("Found invalid column while creating list of shown columns!", Color.Red);
+                            hideList.Items.Add("<unknown>");
+                            break;
+                    }
+                }
+
+                downloads.HideColumns(new List<Column> { Column.received }, new List<Column> { Column.fileName, Column.progress, Column.size, Column.url });
+            }
         }
     }
 }

--- a/ColumnEditor.resx
+++ b/ColumnEditor.resx
@@ -117,24 +117,6 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <metadata name="FileNameColumn.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="ProgressColumn.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="UrlColumn.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="SizeColumn.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="timer.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>17, 17</value>
-  </metadata>
-  <metadata name="menuStrip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>100, 17</value>
-  </metadata>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="$this.Icon" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>

--- a/Controls/DataViewProgressColumn.cs
+++ b/Controls/DataViewProgressColumn.cs
@@ -1,0 +1,174 @@
+﻿using System.Drawing.Drawing2D;
+
+namespace DownloadManager.Controls
+{
+    public class DataGridViewProgressColumn : DataGridViewImageColumn
+    {
+        public DataGridViewProgressColumn()
+        {
+            CellTemplate = new DataGridViewProgressCell();
+        }
+    }
+}
+namespace DownloadManager.Controls
+{
+    public class DataGridViewProgressCell : DataGridViewImageCell
+    {
+        internal System.Windows.Forms.Timer marqueeTimer = new System.Windows.Forms.Timer();
+        internal Rectangle progressBarBounds = Rectangle.Empty;
+        internal int marqueePosition = 0;
+
+        public DataGridViewProgressCell()
+        {
+            try
+            {
+                this.Tag = 10;
+                // Create a timer to update the marquee position
+                marqueeTimer.Interval = 30;
+                marqueeTimer.Tick += MarqueeTimer_Tick;
+                //marqueeTimer.Start();
+            }
+            catch (Exception ex)
+            {
+                if (System.ComponentModel.LicenseManager.UsageMode != System.ComponentModel.LicenseUsageMode.Designtime)
+                {
+                    Logging.Log($"[DataViewProgressColumnControl] {ex.Message} ({ex.GetType().FullName})\n{ex.StackTrace}", Color.Red);
+                }
+                else
+                {
+                    Console.WriteLine($"[DataViewProgressColumnControl] {ex.Message} ({ex.GetType().FullName})\n{ex.StackTrace}");
+                }
+            }
+        }
+
+        private void MarqueeTimer_Tick(object sender, EventArgs e)
+        {
+            /*try
+            {
+                if (System.ComponentModel.LicenseManager.UsageMode != System.ComponentModel.LicenseUsageMode.Designtime)
+                {
+                    if (progressBarBounds.Width != 0)
+                    {
+                        // Update the marquee position
+                        marqueePosition = (marqueePosition + 5) % (progressBarBounds.Width + progressBarBounds.Width / 3);
+
+                        // Redraw the control
+                        //this.DataGridView.Refresh();
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                if (System.ComponentModel.LicenseManager.UsageMode != System.ComponentModel.LicenseUsageMode.Designtime)
+                {
+                    Logging.Log($"[DataViewProgressColumnControl] {ex.Message} ({ex.GetType().FullName})\n{ex.StackTrace}", Color.Red);
+                }
+                else
+                {
+                    Console.WriteLine($"[DataViewProgressColumnControl] {ex.Message} ({ex.GetType().FullName})\n{ex.StackTrace}");
+                }
+            }*/
+        }
+
+        // Override Paint method
+        protected override void Paint(Graphics g, Rectangle clipBounds, Rectangle cellBounds, int rowIndex, DataGridViewElementStates cellState, object value, object formattedValue, string errorText, DataGridViewCellStyle cellStyle, DataGridViewAdvancedBorderStyle advancedBorderStyle, DataGridViewPaintParts paintParts)
+        {
+            try
+            {
+                try
+                {
+                    if (System.ComponentModel.LicenseManager.UsageMode != System.ComponentModel.LicenseUsageMode.Designtime)
+                    {
+                        if (progressBarBounds.Width != 0)
+                        {
+                            // Update the marquee position
+                            marqueePosition = (marqueePosition + 5) % (progressBarBounds.Width + progressBarBounds.Width / 3);
+
+                            // Redraw the control
+                            //this.DataGridView.Refresh();
+                        }
+                    }
+                }
+                catch (Exception ex)
+                {
+                    if (System.ComponentModel.LicenseManager.UsageMode != System.ComponentModel.LicenseUsageMode.Designtime)
+                    {
+                        Logging.Log($"[DataViewProgressColumnControl] {ex.Message} ({ex.GetType().FullName})\n{ex.StackTrace}", Color.Red);
+                    }
+                    else
+                    {
+                        Console.WriteLine($"[DataViewProgressColumnControl] {ex.Message} ({ex.GetType().FullName})\n{ex.StackTrace}");
+                    }
+                }
+
+                progressBarBounds = cellBounds;
+
+                int progressVal = (int)Tag;
+                float percentage = ((float)progressVal / 100.0f); // assuming value is in percentage
+                Brush backColorBrush = new SolidBrush(cellStyle.BackColor);
+                Brush foreColorBrush = new SolidBrush(cellStyle.ForeColor);
+
+                // base.Paint - Paints the cell background.
+                base.Paint(g, clipBounds, cellBounds, rowIndex, cellState, (int)Tag, 0, errorText, cellStyle, advancedBorderStyle, (paintParts & ~DataGridViewPaintParts.ContentForeground));
+
+                if (progressVal >= 0)
+                {
+                    // Draw the progress bar and the text
+                    int width = (int)(cellBounds.Width * ((int)Tag / 100));
+                    g.FillRectangle(Brushes.Blue, cellBounds.X, cellBounds.Y, width, cellBounds.Height);
+
+                    // Draw the text
+                    using (StringFormat format = new StringFormat())
+                    {
+                        format.Alignment = StringAlignment.Center;
+                        format.LineAlignment = StringAlignment.Center;
+
+                        // Calculate the percentage of the progress bar
+                        int percent = (int)(((int)Tag / (double)100) * 100);
+
+                        // Draw the percentage text
+                        g.DrawString(percent + "%", cellStyle.Font, Brushes.White, cellBounds, format);
+                    }
+
+                    //g.FillRectangle(new SolidBrush(Color.FromArgb(0, 0, 255)), cellBounds.X, cellBounds.Y + 2, Convert.ToInt32((percentage * cellBounds.Width - 4)), cellBounds.Height - 4);
+                    //g.DrawString(progressVal.ToString() + "%", cellStyle.Font, foreColorBrush, cellBounds.X + (cellBounds.Width / 2) - 5, cellBounds.Y + 2);
+                }
+                else
+                {
+                    if (this.DataGridView.CurrentRow == null)
+                    {
+                        return;
+                    }
+
+                    g.SetClip(cellBounds, CombineMode.Replace);
+
+                    // Calculate the width of the marquee block
+                    int width = cellBounds.Width / 3;
+                    // Calculate the x-coordinate of the left edge of the marquee block
+                    int x = cellBounds.X + marqueePosition - width;
+                    // Draw the marquee-style progress bar
+                    g.FillRectangle(Brushes.Blue, x, cellBounds.Y, width, cellBounds.Height);
+
+                    // draw the text
+                    if (this.DataGridView.CurrentRow.Index == rowIndex)
+                        g.DrawString("Processing...", cellStyle.Font, new SolidBrush(cellStyle.SelectionForeColor), cellBounds.X + 6, cellBounds.Y + 2);
+                    else
+                        g.DrawString("Processing...", cellStyle.Font, foreColorBrush, cellBounds.X + 6, cellBounds.Y + 2);
+
+                    g.ResetClip();
+                }
+            }
+            catch (Exception ex)
+            {
+                if (System.ComponentModel.LicenseManager.UsageMode != System.ComponentModel.LicenseUsageMode.Designtime)
+                {
+                    Logging.Log($"[DataViewProgressColumnControl] {ex.Message} ({ex.GetType().FullName})\n{ex.StackTrace}", Color.Red);
+                }
+                else
+                {
+                    Console.WriteLine($"[DataViewProgressColumnControl] {ex.Message} ({ex.GetType().FullName})\n{ex.StackTrace}");
+                }
+            }
+        }
+    }
+}

--- a/Controls/DataViewProgressColumn.cs
+++ b/Controls/DataViewProgressColumn.cs
@@ -14,7 +14,6 @@ namespace DownloadManager.Controls
 {
     public class DataGridViewProgressCell : DataGridViewImageCell
     {
-        internal System.Windows.Forms.Timer marqueeTimer = new System.Windows.Forms.Timer();
         internal Rectangle progressBarBounds = Rectangle.Empty;
         internal int marqueePosition = 0;
 
@@ -22,11 +21,7 @@ namespace DownloadManager.Controls
         {
             try
             {
-                this.Tag = 10;
-                // Create a timer to update the marquee position
-                marqueeTimer.Interval = 30;
-                marqueeTimer.Tick += MarqueeTimer_Tick;
-                //marqueeTimer.Start();
+                this.Tag = -1;
             }
             catch (Exception ex)
             {
@@ -39,35 +34,6 @@ namespace DownloadManager.Controls
                     Console.WriteLine($"[DataViewProgressColumnControl] {ex.Message} ({ex.GetType().FullName})\n{ex.StackTrace}");
                 }
             }
-        }
-
-        private void MarqueeTimer_Tick(object sender, EventArgs e)
-        {
-            /*try
-            {
-                if (System.ComponentModel.LicenseManager.UsageMode != System.ComponentModel.LicenseUsageMode.Designtime)
-                {
-                    if (progressBarBounds.Width != 0)
-                    {
-                        // Update the marquee position
-                        marqueePosition = (marqueePosition + 5) % (progressBarBounds.Width + progressBarBounds.Width / 3);
-
-                        // Redraw the control
-                        //this.DataGridView.Refresh();
-                    }
-                }
-            }
-            catch (Exception ex)
-            {
-                if (System.ComponentModel.LicenseManager.UsageMode != System.ComponentModel.LicenseUsageMode.Designtime)
-                {
-                    Logging.Log($"[DataViewProgressColumnControl] {ex.Message} ({ex.GetType().FullName})\n{ex.StackTrace}", Color.Red);
-                }
-                else
-                {
-                    Console.WriteLine($"[DataViewProgressColumnControl] {ex.Message} ({ex.GetType().FullName})\n{ex.StackTrace}");
-                }
-            }*/
         }
 
         // Override Paint method
@@ -83,9 +49,6 @@ namespace DownloadManager.Controls
                         {
                             // Update the marquee position
                             marqueePosition = (marqueePosition + 5) % (progressBarBounds.Width + progressBarBounds.Width / 3);
-
-                            // Redraw the control
-                            //this.DataGridView.Refresh();
                         }
                     }
                 }
@@ -114,8 +77,7 @@ namespace DownloadManager.Controls
                 if (progressVal >= 0)
                 {
                     // Draw the progress bar and the text
-                    int width = (int)(cellBounds.Width * ((int)Tag / 100));
-                    g.FillRectangle(Brushes.Blue, cellBounds.X, cellBounds.Y, width, cellBounds.Height);
+                    g.FillRectangle(new SolidBrush(Color.FromArgb(0, 0, 255)), cellBounds.X, cellBounds.Y + 2, Convert.ToInt32((percentage * cellBounds.Width - 4)), cellBounds.Height - 4);
 
                     // Draw the text
                     using (StringFormat format = new StringFormat())
@@ -129,9 +91,6 @@ namespace DownloadManager.Controls
                         // Draw the percentage text
                         g.DrawString(percent + "%", cellStyle.Font, Brushes.White, cellBounds, format);
                     }
-
-                    //g.FillRectangle(new SolidBrush(Color.FromArgb(0, 0, 255)), cellBounds.X, cellBounds.Y + 2, Convert.ToInt32((percentage * cellBounds.Width - 4)), cellBounds.Height - 4);
-                    //g.DrawString(progressVal.ToString() + "%", cellStyle.Font, foreColorBrush, cellBounds.X + (cellBounds.Width / 2) - 5, cellBounds.Y + 2);
                 }
                 else
                 {

--- a/CurrentDownloads.Designer.cs
+++ b/CurrentDownloads.Designer.cs
@@ -35,6 +35,7 @@
             FileNameColumn = new DataGridViewTextBoxColumn();
             ProgressColumn = new Controls.DataGridViewProgressColumn();
             UrlColumn = new DataGridViewLinkColumn();
+            TotalReceived = new DataGridViewTextBoxColumn();
             SizeColumn = new DataGridViewTextBoxColumn();
             timer = new System.Windows.Forms.Timer(components);
             menuStrip1 = new MenuStrip();
@@ -58,7 +59,7 @@
             progressGridView.BorderStyle = BorderStyle.None;
             progressGridView.CellBorderStyle = DataGridViewCellBorderStyle.Sunken;
             progressGridView.ColumnHeadersHeightSizeMode = DataGridViewColumnHeadersHeightSizeMode.AutoSize;
-            progressGridView.Columns.AddRange(new DataGridViewColumn[] { FileNameColumn, ProgressColumn, UrlColumn, SizeColumn });
+            progressGridView.Columns.AddRange(new DataGridViewColumn[] { FileNameColumn, ProgressColumn, UrlColumn, TotalReceived, SizeColumn });
             progressGridView.Dock = DockStyle.Fill;
             progressGridView.EditMode = DataGridViewEditMode.EditProgrammatically;
             progressGridView.GridColor = Color.Gray;
@@ -76,7 +77,7 @@
             progressGridView.RowHeadersDefaultCellStyle = dataGridViewCellStyle1;
             progressGridView.RowHeadersVisible = false;
             progressGridView.RowTemplate.Height = 25;
-            progressGridView.ScrollBars = ScrollBars.None;
+            progressGridView.ScrollBars = ScrollBars.Vertical;
             progressGridView.SelectionMode = DataGridViewSelectionMode.FullRowSelect;
             progressGridView.ShowCellErrors = false;
             progressGridView.ShowCellToolTips = false;
@@ -84,7 +85,6 @@
             progressGridView.ShowRowErrors = false;
             progressGridView.Size = new Size(479, 456);
             progressGridView.TabIndex = 1;
-            progressGridView.CellContentClick += progressGridView_CellContentClick;
             progressGridView.DataError += progressGridView_DataError;
             // 
             // FileNameColumn
@@ -109,6 +109,13 @@
             UrlColumn.ReadOnly = true;
             UrlColumn.SortMode = DataGridViewColumnSortMode.Programmatic;
             UrlColumn.Width = 110;
+            // 
+            // TotalReceived
+            // 
+            TotalReceived.HeaderText = "Received";
+            TotalReceived.Name = "TotalReceived";
+            TotalReceived.ReadOnly = true;
+            TotalReceived.Width = 60;
             // 
             // SizeColumn
             // 
@@ -223,6 +230,7 @@
         private DataGridViewTextBoxColumn FileNameColumn;
         private Controls.DataGridViewProgressColumn ProgressColumn;
         private DataGridViewLinkColumn UrlColumn;
+        private DataGridViewTextBoxColumn TotalReceived;
         private DataGridViewTextBoxColumn SizeColumn;
     }
 }

--- a/CurrentDownloads.Designer.cs
+++ b/CurrentDownloads.Designer.cs
@@ -37,7 +37,15 @@
             UrlColumn = new DataGridViewLinkColumn();
             SizeColumn = new DataGridViewTextBoxColumn();
             timer = new System.Windows.Forms.Timer(components);
+            menuStrip1 = new MenuStrip();
+            columnsToolStripMenuItem = new ToolStripMenuItem();
+            selectColumnsToolStripMenuItem = new ToolStripMenuItem();
+            actionsToolStripMenuItem = new ToolStripMenuItem();
+            showSelectedDownloadToolStripMenuItem = new ToolStripMenuItem();
+            hideSelectedDownloadWindowToolStripMenuItem = new ToolStripMenuItem();
+            cancelSelectedDownloadToolStripMenuItem = new ToolStripMenuItem();
             ((System.ComponentModel.ISupportInitialize)progressGridView).BeginInit();
+            menuStrip1.SuspendLayout();
             SuspendLayout();
             // 
             // progressGridView
@@ -54,7 +62,8 @@
             progressGridView.Dock = DockStyle.Fill;
             progressGridView.EditMode = DataGridViewEditMode.EditProgrammatically;
             progressGridView.GridColor = Color.Gray;
-            progressGridView.Location = new Point(0, 0);
+            progressGridView.Location = new Point(0, 24);
+            progressGridView.MultiSelect = false;
             progressGridView.Name = "progressGridView";
             progressGridView.ReadOnly = true;
             dataGridViewCellStyle1.Alignment = DataGridViewContentAlignment.MiddleLeft;
@@ -72,8 +81,9 @@
             progressGridView.ShowCellToolTips = false;
             progressGridView.ShowEditingIcon = false;
             progressGridView.ShowRowErrors = false;
-            progressGridView.Size = new Size(479, 480);
+            progressGridView.Size = new Size(479, 456);
             progressGridView.TabIndex = 1;
+            progressGridView.CellContentClick += progressGridView_CellContentClick;
             progressGridView.DataError += progressGridView_DataError;
             // 
             // FileNameColumn
@@ -113,6 +123,58 @@
             timer.Interval = 200;
             timer.Tick += timer_Tick;
             // 
+            // menuStrip1
+            // 
+            menuStrip1.Items.AddRange(new ToolStripItem[] { columnsToolStripMenuItem, actionsToolStripMenuItem });
+            menuStrip1.Location = new Point(0, 0);
+            menuStrip1.Name = "menuStrip1";
+            menuStrip1.RenderMode = ToolStripRenderMode.System;
+            menuStrip1.Size = new Size(479, 24);
+            menuStrip1.TabIndex = 2;
+            menuStrip1.Text = "menuStrip";
+            // 
+            // columnsToolStripMenuItem
+            // 
+            columnsToolStripMenuItem.DropDownItems.AddRange(new ToolStripItem[] { selectColumnsToolStripMenuItem });
+            columnsToolStripMenuItem.Name = "columnsToolStripMenuItem";
+            columnsToolStripMenuItem.Size = new Size(67, 20);
+            columnsToolStripMenuItem.Text = "Columns";
+            // 
+            // selectColumnsToolStripMenuItem
+            // 
+            selectColumnsToolStripMenuItem.Name = "selectColumnsToolStripMenuItem";
+            selectColumnsToolStripMenuItem.Size = new Size(197, 22);
+            selectColumnsToolStripMenuItem.Text = "Add/Remove Columns";
+            selectColumnsToolStripMenuItem.Click += selectColumnsToolStripMenuItem_Click;
+            // 
+            // actionsToolStripMenuItem
+            // 
+            actionsToolStripMenuItem.DropDownItems.AddRange(new ToolStripItem[] { showSelectedDownloadToolStripMenuItem, hideSelectedDownloadWindowToolStripMenuItem, cancelSelectedDownloadToolStripMenuItem });
+            actionsToolStripMenuItem.Name = "actionsToolStripMenuItem";
+            actionsToolStripMenuItem.Size = new Size(59, 20);
+            actionsToolStripMenuItem.Text = "Actions";
+            // 
+            // showSelectedDownloadToolStripMenuItem
+            // 
+            showSelectedDownloadToolStripMenuItem.Name = "showSelectedDownloadToolStripMenuItem";
+            showSelectedDownloadToolStripMenuItem.Size = new Size(260, 22);
+            showSelectedDownloadToolStripMenuItem.Text = "Show Selected Download Window";
+            showSelectedDownloadToolStripMenuItem.Click += showSelectedDownloadToolStripMenuItem_Click;
+            // 
+            // hideSelectedDownloadWindowToolStripMenuItem
+            // 
+            hideSelectedDownloadWindowToolStripMenuItem.Name = "hideSelectedDownloadWindowToolStripMenuItem";
+            hideSelectedDownloadWindowToolStripMenuItem.Size = new Size(260, 22);
+            hideSelectedDownloadWindowToolStripMenuItem.Text = "Hide Selected Download Window";
+            hideSelectedDownloadWindowToolStripMenuItem.Click += hideSelectedDownloadWindowToolStripMenuItem_Click;
+            // 
+            // cancelSelectedDownloadToolStripMenuItem
+            // 
+            cancelSelectedDownloadToolStripMenuItem.Name = "cancelSelectedDownloadToolStripMenuItem";
+            cancelSelectedDownloadToolStripMenuItem.Size = new Size(260, 22);
+            cancelSelectedDownloadToolStripMenuItem.Text = "Cancel Selected Download";
+            cancelSelectedDownloadToolStripMenuItem.Click += cancelSelectedDownloadToolStripMenuItem_Click;
+            // 
             // CurrentDownloads
             // 
             AutoScaleDimensions = new SizeF(7F, 16F);
@@ -120,21 +182,27 @@
             BackColor = Color.Black;
             ClientSize = new Size(479, 480);
             Controls.Add(progressGridView);
+            Controls.Add(menuStrip1);
             ForeColor = Color.White;
             FormBorderStyle = FormBorderStyle.SizableToolWindow;
             Icon = (Icon)resources.GetObject("$this.Icon");
+            MainMenuStrip = menuStrip1;
             MaximizeBox = false;
             MinimizeBox = false;
-            MinimumSize = new Size(480, 400);
+            MinimumSize = new Size(495, 400);
             Name = "CurrentDownloads";
             Text = "Donwload Manager | Current Downloads";
             FormClosing += CurrentDownloads_FormClosing;
+            Load += CurrentDownloads_Load;
             Shown += CurrentDownloads_Shown;
             ResizeEnd += CurrentDownloads_ResizeEnd;
             Move += CurrentDownloads_Move;
             Resize += CurrentDownloads_Resize;
             ((System.ComponentModel.ISupportInitialize)progressGridView).EndInit();
+            menuStrip1.ResumeLayout(false);
+            menuStrip1.PerformLayout();
             ResumeLayout(false);
+            PerformLayout();
         }
 
         #endregion
@@ -144,6 +212,13 @@
         public Panel panel1;
         public DataGridView progressGridView;
         private System.Windows.Forms.Timer timer;
+        private MenuStrip menuStrip1;
+        private ToolStripMenuItem columnsToolStripMenuItem;
+        private ToolStripMenuItem selectColumnsToolStripMenuItem;
+        private ToolStripMenuItem actionsToolStripMenuItem;
+        private ToolStripMenuItem showSelectedDownloadToolStripMenuItem;
+        private ToolStripMenuItem hideSelectedDownloadWindowToolStripMenuItem;
+        private ToolStripMenuItem cancelSelectedDownloadToolStripMenuItem;
         private DataGridViewTextBoxColumn FileNameColumn;
         private Controls.DataGridViewProgressColumn ProgressColumn;
         private DataGridViewLinkColumn UrlColumn;

--- a/CurrentDownloads.Designer.cs
+++ b/CurrentDownloads.Designer.cs
@@ -76,6 +76,7 @@
             progressGridView.RowHeadersDefaultCellStyle = dataGridViewCellStyle1;
             progressGridView.RowHeadersVisible = false;
             progressGridView.RowTemplate.Height = 25;
+            progressGridView.ScrollBars = ScrollBars.None;
             progressGridView.SelectionMode = DataGridViewSelectionMode.FullRowSelect;
             progressGridView.ShowCellErrors = false;
             progressGridView.ShowCellToolTips = false;

--- a/CurrentDownloads.Designer.cs
+++ b/CurrentDownloads.Designer.cs
@@ -130,6 +130,7 @@
             Text = "Donwload Manager | Current Downloads";
             FormClosing += CurrentDownloads_FormClosing;
             Shown += CurrentDownloads_Shown;
+            ResizeEnd += CurrentDownloads_ResizeEnd;
             Move += CurrentDownloads_Move;
             Resize += CurrentDownloads_Resize;
             ((System.ComponentModel.ISupportInitialize)progressGridView).EndInit();

--- a/CurrentDownloads.Designer.cs
+++ b/CurrentDownloads.Designer.cs
@@ -32,11 +32,6 @@
             DataGridViewCellStyle dataGridViewCellStyle1 = new DataGridViewCellStyle();
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(CurrentDownloads));
             progressGridView = new DataGridView();
-            FileNameColumn = new DataGridViewTextBoxColumn();
-            ProgressColumn = new Controls.DataGridViewProgressColumn();
-            UrlColumn = new DataGridViewLinkColumn();
-            TotalReceived = new DataGridViewTextBoxColumn();
-            SizeColumn = new DataGridViewTextBoxColumn();
             timer = new System.Windows.Forms.Timer(components);
             menuStrip1 = new MenuStrip();
             columnsToolStripMenuItem = new ToolStripMenuItem();
@@ -45,6 +40,12 @@
             showSelectedDownloadToolStripMenuItem = new ToolStripMenuItem();
             hideSelectedDownloadWindowToolStripMenuItem = new ToolStripMenuItem();
             cancelSelectedDownloadToolStripMenuItem = new ToolStripMenuItem();
+            FileNameColumn = new DataGridViewTextBoxColumn();
+            ProgressColumn = new Controls.DataGridViewProgressColumn();
+            Speed = new DataGridViewTextBoxColumn();
+            UrlColumn = new DataGridViewLinkColumn();
+            TotalReceived = new DataGridViewTextBoxColumn();
+            SizeColumn = new DataGridViewTextBoxColumn();
             ((System.ComponentModel.ISupportInitialize)progressGridView).BeginInit();
             menuStrip1.SuspendLayout();
             SuspendLayout();
@@ -59,7 +60,7 @@
             progressGridView.BorderStyle = BorderStyle.None;
             progressGridView.CellBorderStyle = DataGridViewCellBorderStyle.Sunken;
             progressGridView.ColumnHeadersHeightSizeMode = DataGridViewColumnHeadersHeightSizeMode.AutoSize;
-            progressGridView.Columns.AddRange(new DataGridViewColumn[] { FileNameColumn, ProgressColumn, UrlColumn, TotalReceived, SizeColumn });
+            progressGridView.Columns.AddRange(new DataGridViewColumn[] { FileNameColumn, ProgressColumn, Speed, UrlColumn, TotalReceived, SizeColumn });
             progressGridView.Dock = DockStyle.Fill;
             progressGridView.EditMode = DataGridViewEditMode.EditProgrammatically;
             progressGridView.GridColor = Color.Gray;
@@ -86,44 +87,6 @@
             progressGridView.Size = new Size(479, 456);
             progressGridView.TabIndex = 1;
             progressGridView.DataError += progressGridView_DataError;
-            // 
-            // FileNameColumn
-            // 
-            FileNameColumn.HeaderText = "File Name";
-            FileNameColumn.Name = "FileNameColumn";
-            FileNameColumn.ReadOnly = true;
-            FileNameColumn.SortMode = DataGridViewColumnSortMode.Programmatic;
-            FileNameColumn.Width = 209;
-            // 
-            // ProgressColumn
-            // 
-            ProgressColumn.HeaderText = "Progress";
-            ProgressColumn.Name = "ProgressColumn";
-            ProgressColumn.ReadOnly = true;
-            ProgressColumn.SortMode = DataGridViewColumnSortMode.Programmatic;
-            // 
-            // UrlColumn
-            // 
-            UrlColumn.HeaderText = "URL";
-            UrlColumn.Name = "UrlColumn";
-            UrlColumn.ReadOnly = true;
-            UrlColumn.SortMode = DataGridViewColumnSortMode.Programmatic;
-            UrlColumn.Width = 110;
-            // 
-            // TotalReceived
-            // 
-            TotalReceived.HeaderText = "Received";
-            TotalReceived.Name = "TotalReceived";
-            TotalReceived.ReadOnly = true;
-            TotalReceived.Width = 60;
-            // 
-            // SizeColumn
-            // 
-            SizeColumn.HeaderText = "Size";
-            SizeColumn.Name = "SizeColumn";
-            SizeColumn.ReadOnly = true;
-            SizeColumn.SortMode = DataGridViewColumnSortMode.Programmatic;
-            SizeColumn.Width = 60;
             // 
             // timer
             // 
@@ -183,6 +146,50 @@
             cancelSelectedDownloadToolStripMenuItem.Text = "Cancel Selected Download";
             cancelSelectedDownloadToolStripMenuItem.Click += cancelSelectedDownloadToolStripMenuItem_Click;
             // 
+            // FileNameColumn
+            // 
+            FileNameColumn.HeaderText = "File Name";
+            FileNameColumn.Name = "FileNameColumn";
+            FileNameColumn.ReadOnly = true;
+            FileNameColumn.SortMode = DataGridViewColumnSortMode.Programmatic;
+            FileNameColumn.Width = 209;
+            // 
+            // ProgressColumn
+            // 
+            ProgressColumn.HeaderText = "Progress";
+            ProgressColumn.Name = "ProgressColumn";
+            ProgressColumn.ReadOnly = true;
+            ProgressColumn.SortMode = DataGridViewColumnSortMode.Programmatic;
+            // 
+            // Speed
+            // 
+            Speed.HeaderText = "Speed";
+            Speed.Name = "Speed";
+            Speed.ReadOnly = true;
+            // 
+            // UrlColumn
+            // 
+            UrlColumn.HeaderText = "URL";
+            UrlColumn.Name = "UrlColumn";
+            UrlColumn.ReadOnly = true;
+            UrlColumn.SortMode = DataGridViewColumnSortMode.Programmatic;
+            UrlColumn.Width = 110;
+            // 
+            // TotalReceived
+            // 
+            TotalReceived.HeaderText = "Received";
+            TotalReceived.Name = "TotalReceived";
+            TotalReceived.ReadOnly = true;
+            TotalReceived.Width = 60;
+            // 
+            // SizeColumn
+            // 
+            SizeColumn.HeaderText = "Size";
+            SizeColumn.Name = "SizeColumn";
+            SizeColumn.ReadOnly = true;
+            SizeColumn.SortMode = DataGridViewColumnSortMode.Programmatic;
+            SizeColumn.Width = 60;
+            // 
             // CurrentDownloads
             // 
             AutoScaleDimensions = new SizeF(7F, 16F);
@@ -229,6 +236,7 @@
         private ToolStripMenuItem cancelSelectedDownloadToolStripMenuItem;
         private DataGridViewTextBoxColumn FileNameColumn;
         private Controls.DataGridViewProgressColumn ProgressColumn;
+        private DataGridViewTextBoxColumn Speed;
         private DataGridViewLinkColumn UrlColumn;
         private DataGridViewTextBoxColumn TotalReceived;
         private DataGridViewTextBoxColumn SizeColumn;

--- a/CurrentDownloads.Designer.cs
+++ b/CurrentDownloads.Designer.cs
@@ -64,6 +64,7 @@
             dataGridViewCellStyle1.SelectionForeColor = SystemColors.HighlightText;
             dataGridViewCellStyle1.WrapMode = DataGridViewTriState.False;
             progressGridView.RowHeadersDefaultCellStyle = dataGridViewCellStyle1;
+            progressGridView.RowHeadersVisible = false;
             progressGridView.RowTemplate.Height = 25;
             progressGridView.SelectionMode = DataGridViewSelectionMode.FullRowSelect;
             progressGridView.ShowCellErrors = false;

--- a/CurrentDownloads.Designer.cs
+++ b/CurrentDownloads.Designer.cs
@@ -44,6 +44,7 @@
             // 
             progressGridView.AllowUserToAddRows = false;
             progressGridView.AllowUserToDeleteRows = false;
+            progressGridView.AllowUserToResizeColumns = false;
             progressGridView.AllowUserToResizeRows = false;
             progressGridView.BackgroundColor = Color.Black;
             progressGridView.BorderStyle = BorderStyle.None;
@@ -81,6 +82,7 @@
             FileNameColumn.Name = "FileNameColumn";
             FileNameColumn.ReadOnly = true;
             FileNameColumn.SortMode = DataGridViewColumnSortMode.Programmatic;
+            FileNameColumn.Width = 209;
             // 
             // ProgressColumn
             // 
@@ -95,6 +97,7 @@
             UrlColumn.Name = "UrlColumn";
             UrlColumn.ReadOnly = true;
             UrlColumn.SortMode = DataGridViewColumnSortMode.Programmatic;
+            UrlColumn.Width = 110;
             // 
             // SizeColumn
             // 
@@ -102,6 +105,7 @@
             SizeColumn.Name = "SizeColumn";
             SizeColumn.ReadOnly = true;
             SizeColumn.SortMode = DataGridViewColumnSortMode.Programmatic;
+            SizeColumn.Width = 60;
             // 
             // timer
             // 
@@ -121,6 +125,7 @@
             Icon = (Icon)resources.GetObject("$this.Icon");
             MaximizeBox = false;
             MinimizeBox = false;
+            MinimumSize = new Size(480, 400);
             Name = "CurrentDownloads";
             Text = "Donwload Manager | Current Downloads";
             FormClosing += CurrentDownloads_FormClosing;
@@ -136,11 +141,11 @@
         private Button refreshButton;
         private Splitter splitter1;
         public Panel panel1;
+        public DataGridView progressGridView;
+        private System.Windows.Forms.Timer timer;
         private DataGridViewTextBoxColumn FileNameColumn;
         private Controls.DataGridViewProgressColumn ProgressColumn;
         private DataGridViewLinkColumn UrlColumn;
         private DataGridViewTextBoxColumn SizeColumn;
-        public DataGridView progressGridView;
-        private System.Windows.Forms.Timer timer;
     }
 }

--- a/CurrentDownloads.Designer.cs
+++ b/CurrentDownloads.Designer.cs
@@ -28,170 +28,85 @@
         /// </summary>
         private void InitializeComponent()
         {
+            components = new System.ComponentModel.Container();
+            DataGridViewCellStyle dataGridViewCellStyle1 = new DataGridViewCellStyle();
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(CurrentDownloads));
-            groupBox1 = new GroupBox();
-            progressBar1 = new ProgressBar();
-            label8 = new Label();
-            label7 = new Label();
-            label6 = new Label();
-            label5 = new Label();
-            label4 = new Label();
-            label3 = new Label();
-            label2 = new Label();
-            label1 = new Label();
-            panel1 = new Panel();
-            panel2 = new Panel();
-            splitter1 = new Splitter();
-            refreshButton = new Button();
-            groupBox1.SuspendLayout();
-            panel1.SuspendLayout();
-            panel2.SuspendLayout();
+            progressGridView = new DataGridView();
+            FileNameColumn = new DataGridViewTextBoxColumn();
+            ProgressColumn = new Controls.DataGridViewProgressColumn();
+            UrlColumn = new DataGridViewLinkColumn();
+            SizeColumn = new DataGridViewTextBoxColumn();
+            timer = new System.Windows.Forms.Timer(components);
+            ((System.ComponentModel.ISupportInitialize)progressGridView).BeginInit();
             SuspendLayout();
             // 
-            // groupBox1
+            // progressGridView
             // 
-            groupBox1.Controls.Add(progressBar1);
-            groupBox1.Controls.Add(label8);
-            groupBox1.Controls.Add(label7);
-            groupBox1.Controls.Add(label6);
-            groupBox1.Controls.Add(label5);
-            groupBox1.Controls.Add(label4);
-            groupBox1.Controls.Add(label3);
-            groupBox1.Controls.Add(label2);
-            groupBox1.Controls.Add(label1);
-            groupBox1.Location = new Point(12, 13);
-            groupBox1.Name = "groupBox1";
-            groupBox1.Size = new Size(428, 112);
-            groupBox1.TabIndex = 0;
-            groupBox1.TabStop = false;
-            groupBox1.Visible = false;
+            progressGridView.AllowUserToAddRows = false;
+            progressGridView.AllowUserToDeleteRows = false;
+            progressGridView.AllowUserToResizeRows = false;
+            progressGridView.BackgroundColor = Color.Black;
+            progressGridView.BorderStyle = BorderStyle.None;
+            progressGridView.CellBorderStyle = DataGridViewCellBorderStyle.Sunken;
+            progressGridView.ColumnHeadersHeightSizeMode = DataGridViewColumnHeadersHeightSizeMode.AutoSize;
+            progressGridView.Columns.AddRange(new DataGridViewColumn[] { FileNameColumn, ProgressColumn, UrlColumn, SizeColumn });
+            progressGridView.Dock = DockStyle.Fill;
+            progressGridView.EditMode = DataGridViewEditMode.EditProgrammatically;
+            progressGridView.GridColor = Color.Gray;
+            progressGridView.Location = new Point(0, 0);
+            progressGridView.Name = "progressGridView";
+            progressGridView.ReadOnly = true;
+            dataGridViewCellStyle1.Alignment = DataGridViewContentAlignment.MiddleLeft;
+            dataGridViewCellStyle1.BackColor = Color.Black;
+            dataGridViewCellStyle1.Font = new Font("Segoe UI Variable Small", 9F, FontStyle.Regular, GraphicsUnit.Point);
+            dataGridViewCellStyle1.ForeColor = Color.White;
+            dataGridViewCellStyle1.SelectionBackColor = SystemColors.Highlight;
+            dataGridViewCellStyle1.SelectionForeColor = SystemColors.HighlightText;
+            dataGridViewCellStyle1.WrapMode = DataGridViewTriState.False;
+            progressGridView.RowHeadersDefaultCellStyle = dataGridViewCellStyle1;
+            progressGridView.RowTemplate.Height = 25;
+            progressGridView.SelectionMode = DataGridViewSelectionMode.FullRowSelect;
+            progressGridView.ShowCellErrors = false;
+            progressGridView.ShowCellToolTips = false;
+            progressGridView.ShowEditingIcon = false;
+            progressGridView.ShowRowErrors = false;
+            progressGridView.Size = new Size(452, 480);
+            progressGridView.TabIndex = 1;
+            progressGridView.DataError += progressGridView_DataError;
             // 
-            // progressBar1
+            // FileNameColumn
             // 
-            progressBar1.Location = new Point(290, 46);
-            progressBar1.Name = "progressBar1";
-            progressBar1.Size = new Size(121, 25);
-            progressBar1.TabIndex = 1;
+            FileNameColumn.HeaderText = "File Name";
+            FileNameColumn.Name = "FileNameColumn";
+            FileNameColumn.ReadOnly = true;
+            FileNameColumn.SortMode = DataGridViewColumnSortMode.Programmatic;
             // 
-            // label8
+            // ProgressColumn
             // 
-            label8.Font = new Font("Segoe UI", 9F, FontStyle.Regular, GraphicsUnit.Point);
-            label8.Location = new Point(121, 82);
-            label8.Name = "label8";
-            label8.Size = new Size(163, 16);
-            label8.TabIndex = 7;
-            label8.Text = "0%";
+            ProgressColumn.HeaderText = "Progress";
+            ProgressColumn.Name = "ProgressColumn";
+            ProgressColumn.ReadOnly = true;
+            ProgressColumn.SortMode = DataGridViewColumnSortMode.Programmatic;
             // 
-            // label7
+            // UrlColumn
             // 
-            label7.AutoSize = true;
-            label7.Location = new Point(6, 82);
-            label7.Name = "label7";
-            label7.Size = new Size(114, 16);
-            label7.TabIndex = 6;
-            label7.Text = "Download Progress:";
+            UrlColumn.HeaderText = "URL";
+            UrlColumn.Name = "UrlColumn";
+            UrlColumn.ReadOnly = true;
+            UrlColumn.SortMode = DataGridViewColumnSortMode.Programmatic;
             // 
-            // label6
+            // SizeColumn
             // 
-            label6.Font = new Font("Segoe UI", 9F, FontStyle.Regular, GraphicsUnit.Point);
-            label6.Location = new Point(96, 61);
-            label6.Name = "label6";
-            label6.Size = new Size(188, 16);
-            label6.TabIndex = 5;
-            label6.Text = "0 Bytes";
+            SizeColumn.HeaderText = "Size";
+            SizeColumn.Name = "SizeColumn";
+            SizeColumn.ReadOnly = true;
+            SizeColumn.SortMode = DataGridViewColumnSortMode.Programmatic;
             // 
-            // label5
+            // timer
             // 
-            label5.AutoSize = true;
-            label5.Location = new Point(6, 61);
-            label5.Name = "label5";
-            label5.Size = new Size(91, 16);
-            label5.TabIndex = 4;
-            label5.Text = "Download Size:";
-            // 
-            // label4
-            // 
-            label4.Font = new Font("Segoe UI", 9F, FontStyle.Regular, GraphicsUnit.Point);
-            label4.Location = new Point(97, 41);
-            label4.Name = "label4";
-            label4.Size = new Size(187, 16);
-            label4.TabIndex = 3;
-            label4.Text = "FileURL";
-            // 
-            // label3
-            // 
-            label3.AutoSize = true;
-            label3.Location = new Point(6, 41);
-            label3.Name = "label3";
-            label3.Size = new Size(89, 16);
-            label3.TabIndex = 2;
-            label3.Text = "Download URL:";
-            // 
-            // label2
-            // 
-            label2.Font = new Font("Segoe UI", 9F, FontStyle.Bold, GraphicsUnit.Point);
-            label2.Location = new Point(92, 20);
-            label2.Name = "label2";
-            label2.Size = new Size(192, 16);
-            label2.TabIndex = 1;
-            label2.Text = "FileName";
-            // 
-            // label1
-            // 
-            label1.AutoSize = true;
-            label1.Font = new Font("Segoe UI", 9F, FontStyle.Bold, GraphicsUnit.Point);
-            label1.Location = new Point(6, 20);
-            label1.Name = "label1";
-            label1.Size = new Size(83, 15);
-            label1.TabIndex = 0;
-            label1.Text = "Downloading:";
-            // 
-            // panel1
-            // 
-            panel1.AutoScroll = true;
-            panel1.Controls.Add(groupBox1);
-            panel1.Dock = DockStyle.Top;
-            panel1.Location = new Point(0, 0);
-            panel1.Name = "panel1";
-            panel1.Size = new Size(452, 427);
-            panel1.TabIndex = 1;
-            // 
-            // panel2
-            // 
-            panel2.Controls.Add(splitter1);
-            panel2.Controls.Add(refreshButton);
-            panel2.Dock = DockStyle.Bottom;
-            panel2.Location = new Point(0, 430);
-            panel2.Name = "panel2";
-            panel2.Size = new Size(452, 50);
-            panel2.TabIndex = 2;
-            // 
-            // splitter1
-            // 
-            splitter1.BackColor = Color.DimGray;
-            splitter1.Dock = DockStyle.Top;
-            splitter1.Enabled = false;
-            splitter1.Location = new Point(0, 0);
-            splitter1.MinExtra = 1;
-            splitter1.MinSize = 1;
-            splitter1.Name = "splitter1";
-            splitter1.Size = new Size(452, 1);
-            splitter1.TabIndex = 55;
-            splitter1.TabStop = false;
-            // 
-            // refreshButton
-            // 
-            refreshButton.BackColor = Color.Transparent;
-            refreshButton.FlatAppearance.MouseDownBackColor = Color.Gray;
-            refreshButton.FlatStyle = FlatStyle.Flat;
-            refreshButton.ForeColor = Color.White;
-            refreshButton.Location = new Point(185, 13);
-            refreshButton.Name = "refreshButton";
-            refreshButton.Size = new Size(82, 25);
-            refreshButton.TabIndex = 54;
-            refreshButton.Text = "Refresh";
-            refreshButton.UseVisualStyleBackColor = false;
-            refreshButton.Click += refreshButton_Click;
+            timer.Enabled = true;
+            timer.Interval = 200;
+            timer.Tick += timer_Tick;
             // 
             // CurrentDownloads
             // 
@@ -199,8 +114,7 @@
             AutoScaleMode = AutoScaleMode.Font;
             BackColor = Color.Black;
             ClientSize = new Size(452, 480);
-            Controls.Add(panel2);
-            Controls.Add(panel1);
+            Controls.Add(progressGridView);
             ForeColor = Color.White;
             FormBorderStyle = FormBorderStyle.FixedToolWindow;
             Icon = (Icon)resources.GetObject("$this.Icon");
@@ -211,28 +125,20 @@
             FormClosing += CurrentDownloads_FormClosing;
             Shown += CurrentDownloads_Shown;
             Move += CurrentDownloads_Move;
-            groupBox1.ResumeLayout(false);
-            groupBox1.PerformLayout();
-            panel1.ResumeLayout(false);
-            panel2.ResumeLayout(false);
+            ((System.ComponentModel.ISupportInitialize)progressGridView).EndInit();
             ResumeLayout(false);
         }
 
         #endregion
-
-        private GroupBox groupBox1;
-        private ProgressBar progressBar1;
-        private Label label8;
-        private Label label7;
-        private Label label6;
-        private Label label5;
-        private Label label4;
-        private Label label3;
-        private Label label2;
-        private Label label1;
         private Panel panel2;
         private Button refreshButton;
         private Splitter splitter1;
         public Panel panel1;
+        private DataGridViewTextBoxColumn FileNameColumn;
+        private Controls.DataGridViewProgressColumn ProgressColumn;
+        private DataGridViewLinkColumn UrlColumn;
+        private DataGridViewTextBoxColumn SizeColumn;
+        public DataGridView progressGridView;
+        private System.Windows.Forms.Timer timer;
     }
 }

--- a/CurrentDownloads.Designer.cs
+++ b/CurrentDownloads.Designer.cs
@@ -71,7 +71,7 @@
             progressGridView.ShowCellToolTips = false;
             progressGridView.ShowEditingIcon = false;
             progressGridView.ShowRowErrors = false;
-            progressGridView.Size = new Size(452, 480);
+            progressGridView.Size = new Size(479, 480);
             progressGridView.TabIndex = 1;
             progressGridView.DataError += progressGridView_DataError;
             // 
@@ -114,10 +114,10 @@
             AutoScaleDimensions = new SizeF(7F, 16F);
             AutoScaleMode = AutoScaleMode.Font;
             BackColor = Color.Black;
-            ClientSize = new Size(452, 480);
+            ClientSize = new Size(479, 480);
             Controls.Add(progressGridView);
             ForeColor = Color.White;
-            FormBorderStyle = FormBorderStyle.FixedToolWindow;
+            FormBorderStyle = FormBorderStyle.SizableToolWindow;
             Icon = (Icon)resources.GetObject("$this.Icon");
             MaximizeBox = false;
             MinimizeBox = false;
@@ -126,6 +126,7 @@
             FormClosing += CurrentDownloads_FormClosing;
             Shown += CurrentDownloads_Shown;
             Move += CurrentDownloads_Move;
+            Resize += CurrentDownloads_Resize;
             ((System.ComponentModel.ISupportInitialize)progressGridView).EndInit();
             ResumeLayout(false);
         }

--- a/CurrentDownloads.cs
+++ b/CurrentDownloads.cs
@@ -114,10 +114,10 @@ namespace DownloadManager
         {
             fileName = 0,
             progress = 1,
-            url = 2,
-            received = 3,
-            size = 4,
-            speed = 5
+            speed = 2,
+            url = 3,
+            received = 4,
+            size = 5,
         }
 
         public Task HideAfterFirstShow()

--- a/CurrentDownloads.cs
+++ b/CurrentDownloads.cs
@@ -139,5 +139,11 @@ namespace DownloadManager
         {
             progressGridView.Refresh();
         }
+
+        private void CurrentDownloads_Resize(object sender, EventArgs e)
+        {
+            // Move the window to to correct location while resizing
+            CurrentDownloads_Move(sender, e);
+        }
     }
 }

--- a/CurrentDownloads.cs
+++ b/CurrentDownloads.cs
@@ -23,6 +23,15 @@ namespace DownloadManager
             DesktopWindowManager.EnableMicaIfSupported(this.Handle);
             DesktopWindowManager.ExtendFrameIntoClientArea(this.Handle);
 
+            // Resize the window based on the last saved size
+            this.Size = Settings.Default.currentDownloadsSize;
+
+            // Resize columns based on the new size
+            progressGridView.Columns[0].Width = this.Width - 287;
+
+            // Move the window to to correct location while resizing
+            CurrentDownloads_Move(new object(), new EventArgs());
+
             // Double buffer the progressGridView control
             typeof(DataGridView).InvokeMember("DoubleBuffered",
                 BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.SetProperty,
@@ -142,9 +151,18 @@ namespace DownloadManager
 
         private void CurrentDownloads_Resize(object sender, EventArgs e)
         {
-            // Move the window to to correct location while resizing
+            // Resize columns based on the new size
             progressGridView.Columns[0].Width = this.Width - 287;
+
+            // Move the window to to correct location while resizing
             CurrentDownloads_Move(sender, e);
+        }
+
+        private void CurrentDownloads_ResizeEnd(object sender, EventArgs e)
+        {
+            // Save the size of the window
+            Settings.Default.currentDownloadsSize = this.Size;
+            Settings.Default.Save();
         }
     }
 }

--- a/CurrentDownloads.cs
+++ b/CurrentDownloads.cs
@@ -1,4 +1,6 @@
-﻿using DownloadManager.NativeMethods;
+﻿using AngleSharp.Text;
+using DownloadManager.NativeMethods;
+using System.Diagnostics;
 using System.Reflection;
 
 namespace DownloadManager
@@ -8,17 +10,16 @@ namespace DownloadManager
         internal bool ForceActiveBar { get; set; }
         public static CurrentDownloads _instance;
         public List<DownloadItem> itemList = new List<DownloadItem>();
-        public static int nextY = 12;
 
         public static bool firstShown = true;
         public static bool firstShownDataError = true;
+        public int columnsSize = 0;
 
         public CurrentDownloads()
         {
             _instance = this;
             InitializeComponent();
             this.ForceActiveBar = true;
-
             DesktopWindowManager.SetImmersiveDarkMode(this.Handle, true);
             DesktopWindowManager.EnableMicaIfSupported(this.Handle);
             DesktopWindowManager.ExtendFrameIntoClientArea(this.Handle);
@@ -26,16 +27,97 @@ namespace DownloadManager
             // Resize the window based on the last saved size
             this.Size = Settings.Default.currentDownloadsSize;
 
-            // Resize columns based on the new size
-            progressGridView.Columns[0].Width = this.Width - 286;
-
-            // Move the window to to correct location while resizing
-            CurrentDownloads_Move(new object(), new EventArgs());
-
             // Double buffer the progressGridView control
             typeof(DataGridView).InvokeMember("DoubleBuffered",
                 BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.SetProperty,
                 null, progressGridView, new object[] { true });
+
+            // Move the window to to correct location while resizing
+            CurrentDownloads_Move(new object(), new EventArgs());
+        }
+
+        private void CurrentDownloads_Load(object sender, EventArgs e)
+        {
+            // Get a list of hidden columns
+            List<Column> hiddenColumns = new List<Column>();
+            foreach (string item in Settings.Default.currentDownloadsHiddenColumns)
+            {
+                Application.DoEvents();
+                int columnType = item.ToInteger(-1);
+                if (columnType == -1)
+                {
+                    Logging.Log("Setting 'currentDownloadsHiddenColumns' contains invalid values! Ignoring invalid values, some unexpected columns may be shown.", Color.Orange);
+                }
+                hiddenColumns.Add((Column)columnType);
+            }
+
+            // get a list of the shown columns
+            List<Column> shownColumns = new List<Column>();
+            foreach (string item in Settings.Default.currentDownloadsShownColumns)
+            {
+                Application.DoEvents();
+                int columnType = item.ToInteger(-1);
+                if (columnType == -1)
+                {
+                    Logging.Log("Setting 'currentDownloadsShownColumns' contains invalid values! Ignoring invalid values, some unexpected columns may be hidden.", Color.Orange);
+                }
+                shownColumns.Add((Column)columnType);
+            }
+
+            // Show/hide columns
+            HideColumns(hiddenColumns, shownColumns);
+
+            // Resize columns based on the new size
+            int totalColumnWidth = progressGridView.Columns.Cast<DataGridViewColumn>()
+            .Where(c => c.HeaderText != "File Name" && c.Visible)
+            .Sum(c => c.Width);
+
+            progressGridView.Columns[0].Width = this.Width - totalColumnWidth - 16;
+
+            this.MinimumSize = new Size(totalColumnWidth + 209, this.MinimumSize.Height);
+        }
+
+        public void HideColumns(List<Column> hideColumns, List<Column> showColumns)
+        {
+            foreach (Column column in hideColumns)
+            {
+                Application.DoEvents();
+                progressGridView.Columns[(int)column].Visible = false;
+                Debug.WriteLine($"Hiding column {column}.");
+            }
+
+            foreach (Column column in showColumns)
+            {
+                Application.DoEvents();
+                progressGridView.Columns[(int)column].Visible = true;
+                if (column != Column.fileName)
+                {
+                    columnsSize += progressGridView.Columns[(int)column].Width;
+                }
+                Debug.WriteLine($"Showing column {column}.");
+            }
+
+            int totalColumnWidth = progressGridView.Columns.Cast<DataGridViewColumn>()
+            .Where(c => c.HeaderText != "File Name" && c.Visible)
+            .Sum(c => c.Width);
+
+            this.MinimumSize = new Size(totalColumnWidth + 209, this.MinimumSize.Height);
+
+            if (progressGridView.Columns[0].Visible == true)
+            {
+                progressGridView.Columns[0].Width = this.Width - totalColumnWidth - 16;
+            }
+        }
+
+        public enum Column
+        {
+            fileName = 0,
+            progress = 1,
+            url = 2,
+            size = 3,
+            speed = 4,
+            receivedBytes = 5,
+            totalBytes = 6
         }
 
         public Task HideAfterFirstShow()
@@ -152,7 +234,11 @@ namespace DownloadManager
         private void CurrentDownloads_Resize(object sender, EventArgs e)
         {
             // Resize columns based on the new size
-            progressGridView.Columns[0].Width = this.Width - 286;
+            int totalColumnWidth = progressGridView.Columns.Cast<DataGridViewColumn>()
+            .Where(c => c.HeaderText != "File Name" && c.Visible)
+            .Sum(c => c.Width);
+
+            progressGridView.Columns[0].Width = this.Width - totalColumnWidth - 16;
 
             // Move the window to to correct location while resizing
             CurrentDownloads_Move(sender, e);
@@ -163,6 +249,55 @@ namespace DownloadManager
             // Save the size of the window
             Settings.Default.currentDownloadsSize = this.Size;
             Settings.Default.Save();
+        }
+
+        private void progressGridView_CellContentClick(object sender, DataGridViewCellEventArgs e)
+        {
+            // Check if the cell was a button
+            if (e.ColumnIndex == 4)
+            {
+                // Show the related form
+                itemList[e.RowIndex].progress.Show();
+            }
+            else
+            {
+                // Ignore
+                return;
+            }
+        }
+
+        private void showSelectedDownloadToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            // Show selected row associated download window
+            if (progressGridView.SelectedRows.Count != 0)
+                itemList[progressGridView.SelectedRows[0].Index].progress.Show();
+            else
+                new DarkMessageBox("There are no selected items!", "Download Manager", MessageBoxButtons.OK, MessageBoxIcon.Warning).ShowDialog();
+        }
+
+        private void hideSelectedDownloadWindowToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            // Hide selected row associated download window
+            if (progressGridView.SelectedRows.Count != 0)
+                itemList[progressGridView.SelectedRows[0].Index].progress.Hide();
+            else
+                new DarkMessageBox("There are no selected items!", "Download Manager", MessageBoxButtons.OK, MessageBoxIcon.Warning).ShowDialog();
+        }
+
+        private void cancelSelectedDownloadToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            // Cancel the selected download
+            if (progressGridView.SelectedRows.Count != 0)
+                itemList[progressGridView.SelectedRows[0].Index].progress.cancelButton_Click(this, new EventArgs());
+            else
+                new DarkMessageBox("There are no selected items!", "Download Manager", MessageBoxButtons.OK, MessageBoxIcon.Warning).ShowDialog();
+        }
+
+        private void selectColumnsToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            // Open column editor
+            ColumnEditor editor = new ColumnEditor(this);
+            editor.ShowDialog();
         }
     }
 }

--- a/CurrentDownloads.cs
+++ b/CurrentDownloads.cs
@@ -27,7 +27,7 @@ namespace DownloadManager
             this.Size = Settings.Default.currentDownloadsSize;
 
             // Resize columns based on the new size
-            progressGridView.Columns[0].Width = this.Width - 287;
+            progressGridView.Columns[0].Width = this.Width - 286;
 
             // Move the window to to correct location while resizing
             CurrentDownloads_Move(new object(), new EventArgs());
@@ -152,7 +152,7 @@ namespace DownloadManager
         private void CurrentDownloads_Resize(object sender, EventArgs e)
         {
             // Resize columns based on the new size
-            progressGridView.Columns[0].Width = this.Width - 287;
+            progressGridView.Columns[0].Width = this.Width - 286;
 
             // Move the window to to correct location while resizing
             CurrentDownloads_Move(sender, e);

--- a/CurrentDownloads.cs
+++ b/CurrentDownloads.cs
@@ -143,6 +143,7 @@ namespace DownloadManager
         private void CurrentDownloads_Resize(object sender, EventArgs e)
         {
             // Move the window to to correct location while resizing
+            progressGridView.Columns[0].Width = this.Width - 287;
             CurrentDownloads_Move(sender, e);
         }
     }

--- a/CurrentDownloads.resx
+++ b/CurrentDownloads.resx
@@ -126,6 +126,9 @@
   <metadata name="UrlColumn.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
+  <metadata name="TotalReceived.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
   <metadata name="SizeColumn.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>

--- a/CurrentDownloads.resx
+++ b/CurrentDownloads.resx
@@ -117,6 +117,21 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <metadata name="FileNameColumn.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="ProgressColumn.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="UrlColumn.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="SizeColumn.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="timer.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="$this.Icon" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>

--- a/CurrentDownloads.resx
+++ b/CurrentDownloads.resx
@@ -123,6 +123,9 @@
   <metadata name="ProgressColumn.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
+  <metadata name="Speed.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
   <metadata name="UrlColumn.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>

--- a/Download/DownloadProgressUpdater.cs
+++ b/Download/DownloadProgressUpdater.cs
@@ -50,6 +50,10 @@
                 progressWindow.bytesLabel.Text = $"({totalRead} B / {totalLength} B)";
                 progressWindow.receivedBytes = totalRead;
 
+                progressWindow.bytesPerSecond = bytesPerSecond;
+                progressWindow.kilobytesPerSecond = kilobytesPerSecond;
+                progressWindow.megabytesPerSecond = megabytesPerSecond;
+
                 if (megabytesPerSecond > 1)
                 {
                     progressWindow.speedLabel.Text = $"{megabytesPerSecond.ToString("0.00")} MB/s";

--- a/Download/DownloadProgressUpdater.cs
+++ b/Download/DownloadProgressUpdater.cs
@@ -48,6 +48,7 @@
                 double megabytesPerSecond = megabytesPerSecond0 + megabytesPerSecond1;
 
                 progressWindow.bytesLabel.Text = $"({totalRead} B / {totalLength} B)";
+                progressWindow.receivedBytes = totalRead;
 
                 if (megabytesPerSecond > 1)
                 {

--- a/DownloadForm.cs
+++ b/DownloadForm.cs
@@ -71,7 +71,8 @@ namespace DownloadManager
             Settings.Default.currentDownloadsHiddenColumns = new System.Collections.Specialized.StringCollection
                 {
                     // Default hidden column ids go here
-                    "3"
+                    "3",
+                    "4"
                 };
             Settings.Default.currentDownloadsShownColumns = new System.Collections.Specialized.StringCollection
                 {
@@ -79,7 +80,7 @@ namespace DownloadManager
                     "0",
                     "1",
                     "2",
-                    "4"
+                    "5"
                 };
             Settings.Default.Save();
             Logging.Log("Column Preferences Reset!", Color.Orange);

--- a/DownloadForm.cs
+++ b/DownloadForm.cs
@@ -30,6 +30,30 @@ namespace DownloadManager
                 Logging.Log("Download History is null. Performing first time setup.", Color.Orange);
                 Settings.Default.downloadHistory = new System.Collections.Specialized.StringCollection { };
             }
+
+            if (Settings.Default.currentDownloadsHiddenColumns == null)
+            {
+                Logging.Log("Current Downloads hidden columns is null. Performing first time setuo", Color.Orange);
+                Settings.Default.currentDownloadsHiddenColumns = new System.Collections.Specialized.StringCollection
+                {
+                    // Default hidden column ids go here
+                };
+            }
+
+            if (Settings.Default.currentDownloadsShownColumns == null)
+            {
+                Logging.Log("Current Downloads shown columns is null. Performing first time setuo", Color.Orange);
+                Settings.Default.currentDownloadsShownColumns = new System.Collections.Specialized.StringCollection
+                {
+                    // Default shown column ids go here
+                    "0",
+                    "1",
+                    "2",
+                    "3"
+                };
+            }
+
+            Settings.Default.Save();
             InitializeComponent();
 
             DesktopWindowManager.SetImmersiveDarkMode(this.Handle, true);

--- a/DownloadForm.cs
+++ b/DownloadForm.cs
@@ -31,26 +31,10 @@ namespace DownloadManager
                 Settings.Default.downloadHistory = new System.Collections.Specialized.StringCollection { };
             }
 
-            if (Settings.Default.currentDownloadsHiddenColumns == null)
+            if (Settings.Default.currentDownloadsHiddenColumns == null || Settings.Default.currentDownloadsShownColumns == null)
             {
-                Logging.Log("Current Downloads hidden columns is null. Performing first time setuo", Color.Orange);
-                Settings.Default.currentDownloadsHiddenColumns = new System.Collections.Specialized.StringCollection
-                {
-                    // Default hidden column ids go here
-                };
-            }
-
-            if (Settings.Default.currentDownloadsShownColumns == null)
-            {
-                Logging.Log("Current Downloads shown columns is null. Performing first time setuo", Color.Orange);
-                Settings.Default.currentDownloadsShownColumns = new System.Collections.Specialized.StringCollection
-                {
-                    // Default shown column ids go here
-                    "0",
-                    "1",
-                    "2",
-                    "3"
-                };
+                Logging.Log("One or more current downloads column settings are null. Performing first time setuo", Color.Orange);
+                SetupColumnPrefs();
             }
 
             Settings.Default.Save();
@@ -80,6 +64,25 @@ namespace DownloadManager
                     Process.Start(new ProcessStartInfo("https://github.com/Download-Manager-Community/Download-Manager/issues/new?assignees=&labels=bug&projects=&template=bug_report.yml") { UseShellExecute = true });
                 }
             }
+        }
+
+        public void SetupColumnPrefs()
+        {
+            Settings.Default.currentDownloadsHiddenColumns = new System.Collections.Specialized.StringCollection
+                {
+                    // Default hidden column ids go here
+                    "3"
+                };
+            Settings.Default.currentDownloadsShownColumns = new System.Collections.Specialized.StringCollection
+                {
+                    // Default shown column ids go here
+                    "0",
+                    "1",
+                    "2",
+                    "4"
+                };
+            Settings.Default.Save();
+            Logging.Log("Column Preferences Reset!", Color.Orange);
         }
 
         private async void DownloadForm_Shown(object sender, EventArgs e)

--- a/DownloadItem.cs
+++ b/DownloadItem.cs
@@ -7,7 +7,7 @@ namespace DownloadManager
     {
         CurrentDownloads downloadsForm = CurrentDownloads._instance;
         Timer timer = new Timer();
-        DownloadProgress progress;
+        public DownloadProgress progress;
         int index = 0;
         bool isYtDownload = false;
         bool contentLengthIssue = false;

--- a/DownloadItem.cs
+++ b/DownloadItem.cs
@@ -39,7 +39,7 @@ namespace DownloadManager
                 downloadsForm.progressGridView.Rows[index].Cells[2].Value = progress.url;
                 if (progress.totalSize < 1)
                 {
-                    downloadsForm.progressGridView.Rows[index].Cells[3].Value = "? Bytes";
+                    downloadsForm.progressGridView.Rows[index].Cells[3].Value = "? B";
                 }
                 else
                 {

--- a/DownloadItem.cs
+++ b/DownloadItem.cs
@@ -16,12 +16,7 @@ namespace DownloadManager
         {
             this.progress = progress;
 
-            index = downloadsForm.progressGridView.Rows.Add(progress.fileName, progress.percentageDone, progress.url, "? Bytes");
-
-            if (progress.totalSize > 1)
-            {
-                downloadsForm.progressGridView.Rows[index].Cells[3].Value = progress.fileSize + " Bytes";
-            }
+            index = downloadsForm.progressGridView.Rows.Add(progress.fileName, progress.percentageDone, progress.url, "? B");
 
             timer.Tick += UpdateTimer_Tick;
             timer.Interval = 500;
@@ -48,7 +43,27 @@ namespace DownloadManager
                 }
                 else
                 {
-                    downloadsForm.progressGridView.Rows[index].Cells[3].Value = progress.fileSize + " Bytes";
+                    long bytes = progress.totalSize;
+                    long kilobytes = (progress.totalSize / 1024);
+                    long megabytes = ((progress.totalSize / 1024) / 1024);
+                    long gigabytes = (((progress.totalSize / 1024) / 1024) / 1024);
+
+                    if (gigabytes > 1)
+                    {
+                        downloadsForm.progressGridView.Rows[index].Cells[3].Value = $"{gigabytes} GB";
+                    }
+                    else if (megabytes > 1)
+                    {
+                        downloadsForm.progressGridView.Rows[index].Cells[3].Value = $"{megabytes} MB";
+                    }
+                    else if (kilobytes > 1)
+                    {
+                        downloadsForm.progressGridView.Rows[index].Cells[3].Value = $"{kilobytes} KB";
+                    }
+                    else
+                    {
+                        downloadsForm.progressGridView.Rows[index].Cells[3].Value = $"{bytes} B";
+                    }
                 }
 
                 if (progress.downloadType == DownloadProgress.DownloadType.YoutubePlaylist)

--- a/DownloadItem.cs
+++ b/DownloadItem.cs
@@ -35,68 +35,75 @@ namespace DownloadManager
             else
             {
                 // Update the values
-                downloadsForm.progressGridView.Rows[index].Cells[0].Value = progress.fileName;
-                downloadsForm.progressGridView.Rows[index].Cells[2].Value = progress.url;
-                if (progress.totalSize < 1)
+                try
                 {
-                    downloadsForm.progressGridView.Rows[index].Cells[3].Value = "? B";
-                }
-                else
-                {
-                    long bytes = progress.totalSize;
-                    long kilobytes = (progress.totalSize / 1024);
-                    long megabytes = ((progress.totalSize / 1024) / 1024);
-                    long gigabytes = (((progress.totalSize / 1024) / 1024) / 1024);
-
-                    if (gigabytes > 1)
+                    downloadsForm.progressGridView.Rows[index].Cells[0].Value = progress.fileName;
+                    downloadsForm.progressGridView.Rows[index].Cells[2].Value = progress.url;
+                    if (progress.totalSize < 1)
                     {
-                        downloadsForm.progressGridView.Rows[index].Cells[3].Value = $"{gigabytes} GB";
-                    }
-                    else if (megabytes > 1)
-                    {
-                        downloadsForm.progressGridView.Rows[index].Cells[3].Value = $"{megabytes} MB";
-                    }
-                    else if (kilobytes > 1)
-                    {
-                        downloadsForm.progressGridView.Rows[index].Cells[3].Value = $"{kilobytes} KB";
+                        downloadsForm.progressGridView.Rows[index].Cells[3].Value = "? B";
                     }
                     else
                     {
-                        downloadsForm.progressGridView.Rows[index].Cells[3].Value = $"{bytes} B";
-                    }
-                }
+                        long bytes = progress.totalSize;
+                        long kilobytes = (progress.totalSize / 1024);
+                        long megabytes = ((progress.totalSize / 1024) / 1024);
+                        long gigabytes = (((progress.totalSize / 1024) / 1024) / 1024);
 
-                if (progress.downloadType == DownloadProgress.DownloadType.YoutubePlaylist)
-                {
-                    // Update the progressBar
-                    downloadsForm.progressGridView.Rows[index].Cells[1].Value = (int)progress.progressLabel.Text.Replace("%", "").ToDouble();
-                }
-                else if (progress.downloadType == DownloadProgress.DownloadType.YoutubeVideo)
-                {
-                    downloadsForm.progressGridView.Rows[index].Cells[1].Tag = -1;
-                }
-                else
-                {
-                    // Update the progress bar
-                    if ((int)progress.percentageDone > 100)
-                    {
-                        Logging.Log("DownloadItem Progress is greater than 100%! The item has been removed to prevent a crash!", Color.Orange);
-                        Dispose();
+                        if (gigabytes > 1)
+                        {
+                            downloadsForm.progressGridView.Rows[index].Cells[3].Value = $"{gigabytes} GB";
+                        }
+                        else if (megabytes > 1)
+                        {
+                            downloadsForm.progressGridView.Rows[index].Cells[3].Value = $"{megabytes} MB";
+                        }
+                        else if (kilobytes > 1)
+                        {
+                            downloadsForm.progressGridView.Rows[index].Cells[3].Value = $"{kilobytes} KB";
+                        }
+                        else
+                        {
+                            downloadsForm.progressGridView.Rows[index].Cells[3].Value = $"{bytes} B";
+                        }
                     }
 
-                    if (progress.totalSize < 1)
+                    if (progress.downloadType == DownloadProgress.DownloadType.YoutubePlaylist)
                     {
-                        // If the total size is less than 1, then we cannot report progress
-                        // Update the progress bar
+                        // Update the progressBar
+                        downloadsForm.progressGridView.Rows[index].Cells[1].Value = (int)progress.progressLabel.Text.Replace("%", "").ToDouble();
+                    }
+                    else if (progress.downloadType == DownloadProgress.DownloadType.YoutubeVideo)
+                    {
                         downloadsForm.progressGridView.Rows[index].Cells[1].Tag = -1;
                     }
                     else
                     {
                         // Update the progress bar
-                        downloadsForm.progressGridView.Rows[index].Cells[1].Tag = (int)progress.progressLabel.Text.Replace("%", "").ToDouble();
-                    }
+                        if ((int)progress.percentageDone > 100)
+                        {
+                            Logging.Log("DownloadItem Progress is greater than 100%! The item has been removed to prevent a crash!", Color.Orange);
+                            Dispose();
+                        }
 
-                    //Logging.Log(((int)progress.progressLabel.Text.Replace("%", "").ToDouble()).ToString(), Color.Gray);
+                        if (progress.totalSize < 1)
+                        {
+                            // If the total size is less than 1, then we cannot report progress
+                            // Update the progress bar
+                            downloadsForm.progressGridView.Rows[index].Cells[1].Tag = -1;
+                        }
+                        else
+                        {
+                            // Update the progress bar
+                            downloadsForm.progressGridView.Rows[index].Cells[1].Tag = (int)progress.progressLabel.Text.Replace("%", "").ToDouble();
+                        }
+
+                        //Logging.Log(((int)progress.progressLabel.Text.Replace("%", "").ToDouble()).ToString(), Color.Gray);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    Logging.Log($"{ex.Message} ({ex.GetType().FullName})\n{ex.StackTrace}", Color.Red);
                 }
             }
         }
@@ -104,7 +111,14 @@ namespace DownloadManager
         public void Dispose()
         {
             downloadsForm.itemList.Remove(this);
-            downloadsForm.progressGridView.Rows.RemoveAt(index);
+            try
+            {
+                downloadsForm.progressGridView.Rows.RemoveAt(index);
+            }
+            catch (Exception ex)
+            {
+                Logging.Log($"{ex.Message} ({ex.GetType().FullName})\n{ex.StackTrace}", Color.Red);
+            }
 
             timer.Stop();
             timer.Dispose();

--- a/DownloadItem.cs
+++ b/DownloadItem.cs
@@ -1,5 +1,4 @@
 ﻿using AngleSharp.Text;
-using System.Diagnostics;
 using Timer = System.Windows.Forms.Timer;
 
 namespace DownloadManager
@@ -39,10 +38,10 @@ namespace DownloadManager
                 try
                 {
                     downloadsForm.progressGridView.Rows[index].Cells[0].Value = progress.fileName;
-                    downloadsForm.progressGridView.Rows[index].Cells[2].Value = progress.url;
+                    downloadsForm.progressGridView.Rows[index].Cells[3].Value = progress.url;
                     if (progress.totalSize < 1)
                     {
-                        downloadsForm.progressGridView.Rows[index].Cells[4].Value = "? B";
+                        downloadsForm.progressGridView.Rows[index].Cells[5].Value = "? B";
                     }
                     else
                     {
@@ -53,19 +52,19 @@ namespace DownloadManager
 
                         if (totalGigabytes > 1)
                         {
-                            downloadsForm.progressGridView.Rows[index].Cells[4].Value = $"{totalGigabytes.ToString("F1")} GB";
+                            downloadsForm.progressGridView.Rows[index].Cells[5].Value = $"{totalGigabytes.ToString("0.00")} GB";
                         }
                         else if (totalMegabytes > 1)
                         {
-                            downloadsForm.progressGridView.Rows[index].Cells[4].Value = $"{totalMegabytes} MB";
+                            downloadsForm.progressGridView.Rows[index].Cells[5].Value = $"{totalMegabytes.ToString("0.00")} MB";
                         }
                         else if (totalKilobytes > 1)
                         {
-                            downloadsForm.progressGridView.Rows[index].Cells[4].Value = $"{totalKilobytes} KB";
+                            downloadsForm.progressGridView.Rows[index].Cells[5].Value = $"{totalKilobytes.ToString("0.00")} KB";
                         }
                         else
                         {
-                            downloadsForm.progressGridView.Rows[index].Cells[4].Value = $"{totalBytes} B";
+                            downloadsForm.progressGridView.Rows[index].Cells[5].Value = $"{totalBytes.ToString("0.00")} B";
                         }
 
                         long receivedBytes = (long)progress.receivedBytes;
@@ -75,22 +74,40 @@ namespace DownloadManager
 
                         if (receivedGigabytes > 1)
                         {
-                            downloadsForm.progressGridView.Rows[index].Cells[3].Value = receivedGigabytes.ToString("F1") + " GB";
+                            downloadsForm.progressGridView.Rows[index].Cells[4].Value = receivedGigabytes.ToString("0.00") + " GB";
                         }
                         else if (receivedMegabytes > 1)
                         {
-                            downloadsForm.progressGridView.Rows[index].Cells[3].Value = $"{receivedMegabytes} MB";
+                            downloadsForm.progressGridView.Rows[index].Cells[4].Value = $"{receivedMegabytes.ToString("0.00")} MB";
                         }
                         else if (receivedKilobytes > 1)
                         {
-                            downloadsForm.progressGridView.Rows[index].Cells[3].Value = $"{receivedKilobytes} KB";
+                            downloadsForm.progressGridView.Rows[index].Cells[4].Value = $"{receivedKilobytes.ToString("0.00")} KB";
                         }
                         else
                         {
-                            downloadsForm.progressGridView.Rows[index].Cells[3].Value = $"{receivedBytes} B";
+                            downloadsForm.progressGridView.Rows[index].Cells[4].Value = $"{receivedBytes.ToString("0.00")} B";
                         }
 
-                        Debug.WriteLine($"receivedBytes is {receivedBytes} which is:\n{receivedKilobytes}KB, {receivedMegabytes}MB and {receivedGigabytes}GB\n({progress.receivedBytes})");
+                        //Debug.WriteLine($"receivedBytes is {receivedBytes} which is:\n{receivedKilobytes}KB, {receivedMegabytes}MB and {receivedGigabytes}GB\n({progress.receivedBytes})");
+                    }
+
+                    // Display Speed
+                    double bps = progress.bytesPerSecond;
+                    double kbps = progress.kilobytesPerSecond;
+                    double mbps = progress.megabytesPerSecond;
+
+                    if (mbps > 1)
+                    {
+                        downloadsForm.progressGridView.Rows[index].Cells[2].Value = $"{mbps.ToString("0.00")} MB/s";
+                    }
+                    else if (kbps > 1)
+                    {
+                        downloadsForm.progressGridView.Rows[index].Cells[2].Value = $"{kbps.ToString("0.00")} KB/s";
+                    }
+                    else
+                    {
+                        downloadsForm.progressGridView.Rows[index].Cells[2].Value = $"{bps.ToString("0.00")} B/s";
                     }
 
                     if (progress.downloadType == DownloadProgress.DownloadType.YoutubePlaylist)

--- a/DownloadItem.cs
+++ b/DownloadItem.cs
@@ -1,4 +1,5 @@
 ﻿using AngleSharp.Text;
+using System.Diagnostics;
 using Timer = System.Windows.Forms.Timer;
 
 namespace DownloadManager
@@ -41,31 +42,55 @@ namespace DownloadManager
                     downloadsForm.progressGridView.Rows[index].Cells[2].Value = progress.url;
                     if (progress.totalSize < 1)
                     {
-                        downloadsForm.progressGridView.Rows[index].Cells[3].Value = "? B";
+                        downloadsForm.progressGridView.Rows[index].Cells[4].Value = "? B";
                     }
                     else
                     {
-                        long bytes = progress.totalSize;
-                        long kilobytes = (progress.totalSize / 1024);
-                        long megabytes = ((progress.totalSize / 1024) / 1024);
-                        long gigabytes = (((progress.totalSize / 1024) / 1024) / 1024);
+                        long totalBytes = progress.totalSize;
+                        long totalKilobytes = (progress.totalSize / 1024);
+                        long totalMegabytes = ((progress.totalSize / 1024) / 1024);
+                        float totalGigabytes = ((((float)progress.totalSize / 1024) / 1024) / 1024);
 
-                        if (gigabytes > 1)
+                        if (totalGigabytes > 1)
                         {
-                            downloadsForm.progressGridView.Rows[index].Cells[3].Value = $"{gigabytes} GB";
+                            downloadsForm.progressGridView.Rows[index].Cells[4].Value = $"{totalGigabytes.ToString("F1")} GB";
                         }
-                        else if (megabytes > 1)
+                        else if (totalMegabytes > 1)
                         {
-                            downloadsForm.progressGridView.Rows[index].Cells[3].Value = $"{megabytes} MB";
+                            downloadsForm.progressGridView.Rows[index].Cells[4].Value = $"{totalMegabytes} MB";
                         }
-                        else if (kilobytes > 1)
+                        else if (totalKilobytes > 1)
                         {
-                            downloadsForm.progressGridView.Rows[index].Cells[3].Value = $"{kilobytes} KB";
+                            downloadsForm.progressGridView.Rows[index].Cells[4].Value = $"{totalKilobytes} KB";
                         }
                         else
                         {
-                            downloadsForm.progressGridView.Rows[index].Cells[3].Value = $"{bytes} B";
+                            downloadsForm.progressGridView.Rows[index].Cells[4].Value = $"{totalBytes} B";
                         }
+
+                        long receivedBytes = (long)progress.receivedBytes;
+                        long receivedKilobytes = ((long)progress.receivedBytes / 1024);
+                        long receivedMegabytes = (((long)progress.receivedBytes / 1024) / 1024);
+                        float receivedGigabytes = ((((float)progress.receivedBytes / 1024) / 1024) / 1024);
+
+                        if (receivedGigabytes > 1)
+                        {
+                            downloadsForm.progressGridView.Rows[index].Cells[3].Value = receivedGigabytes.ToString("F1") + " GB";
+                        }
+                        else if (receivedMegabytes > 1)
+                        {
+                            downloadsForm.progressGridView.Rows[index].Cells[3].Value = $"{receivedMegabytes} MB";
+                        }
+                        else if (receivedKilobytes > 1)
+                        {
+                            downloadsForm.progressGridView.Rows[index].Cells[3].Value = $"{receivedKilobytes} KB";
+                        }
+                        else
+                        {
+                            downloadsForm.progressGridView.Rows[index].Cells[3].Value = $"{receivedBytes} B";
+                        }
+
+                        Debug.WriteLine($"receivedBytes is {receivedBytes} which is:\n{receivedKilobytes}KB, {receivedMegabytes}MB and {receivedGigabytes}GB\n({progress.receivedBytes})");
                     }
 
                     if (progress.downloadType == DownloadProgress.DownloadType.YoutubePlaylist)
@@ -100,6 +125,11 @@ namespace DownloadManager
 
                         //Logging.Log(((int)progress.progressLabel.Text.Replace("%", "").ToDouble()).ToString(), Color.Gray);
                     }
+                }
+                catch (ArgumentOutOfRangeException)
+                {
+                    // Refresh the list, an item may have completed making the index out of range
+                    downloadsForm.RefreshList();
                 }
                 catch (Exception ex)
                 {

--- a/DownloadItem.cs
+++ b/DownloadItem.cs
@@ -1,4 +1,4 @@
-﻿using static DownloadManager.BetterProgressBar;
+﻿using AngleSharp.Text;
 using Timer = System.Windows.Forms.Timer;
 
 namespace DownloadManager
@@ -8,126 +8,20 @@ namespace DownloadManager
         CurrentDownloads downloadsForm = CurrentDownloads._instance;
         Timer timer = new Timer();
         DownloadProgress progress;
-        GroupBox groupBox;
+        int index = 0;
         bool isYtDownload = false;
         bool contentLengthIssue = false;
-
-        #region Predefined Controls
-        BetterProgressBar progressBar = new BetterProgressBar()
-        {
-            Location = new Point(290, 43),
-            Size = new Size(121, 23),
-            Style = ProgressBarStyle.Marquee,
-            MarqueeAnimationSpeed = 1,
-            MarqueeAnim = true,
-            BackColor = Color.FromArgb(20, 20, 20)
-        };
-
-        Label title1 = new Label()
-        {
-            AutoSize = false,
-            Size = new Size(83, 15),
-            Font = new Font("Segoe UI", 8F, FontStyle.Bold, GraphicsUnit.Point, 0),
-            ForeColor = Color.White,
-            BackColor = Color.Transparent,
-            Location = new Point(6, 19),
-            Text = "Downloading:"
-        };
-        Label fileNameLabel = new Label()
-        {
-            AutoSize = false,
-            Size = new Size(192, 15),
-            Font = new Font("Segoe UI", 8F, FontStyle.Bold, GraphicsUnit.Point, 0),
-            ForeColor = Color.White,
-            BackColor = Color.Transparent,
-            Location = new Point(92, 19),
-            Text = "fileName"
-        };
-        Label title2 = new Label()
-        {
-            AutoSize = false,
-            Size = new Size(88, 15),
-            Font = new Font("Segoe UI", 8F, FontStyle.Regular, GraphicsUnit.Point, 0),
-            ForeColor = Color.White,
-            BackColor = Color.Transparent,
-            Location = new Point(6, 38),
-            Text = "Download URL:"
-        };
-        Label fileUrlLabel = new Label()
-        {
-            AutoSize = false,
-            Size = new Size(187, 15),
-            Font = new Font("Segoe UI", 8F, FontStyle.Regular, GraphicsUnit.Point, 0),
-            ForeColor = Color.White,
-            BackColor = Color.Transparent,
-            Location = new Point(97, 38),
-            Text = "fileUrl"
-        };
-        Label title3 = new Label()
-        {
-            AutoSize = false,
-            Size = new Size(87, 15),
-            Font = new Font("Segoe UI", 8F, FontStyle.Regular, GraphicsUnit.Point, 0),
-            ForeColor = Color.White,
-            BackColor = Color.Transparent,
-            Location = new Point(6, 57),
-            Text = "Download Size:"
-        };
-        Label fileSizeLabel = new Label()
-        {
-            AutoSize = false,
-            Size = new Size(188, 15),
-            Font = new Font("Segoe UI", 8F, FontStyle.Regular, GraphicsUnit.Point, 0),
-            ForeColor = Color.White,
-            BackColor = Color.Transparent,
-            Location = new Point(96, 57),
-            Text = "0 Bytes"
-        };
-        Label title4 = new Label()
-        {
-            AutoSize = false,
-            Size = new Size(112, 15),
-            Font = new Font("Segoe UI", 8F, FontStyle.Regular, GraphicsUnit.Point, 0),
-            ForeColor = Color.White,
-            BackColor = Color.Transparent,
-            Location = new Point(6, 77),
-            Text = "Download Progress:"
-        };
-        Label fileProgressLabel = new Label()
-        {
-            AutoSize = false,
-            Size = new Size(163, 15),
-            Font = new Font("Segoe UI", 8F, FontStyle.Regular, GraphicsUnit.Point, 0),
-            ForeColor = Color.White,
-            BackColor = Color.Transparent,
-            Location = new Point(121, 77),
-            Text = "0%"
-        };
-        #endregion
 
         public void Initialize(DownloadProgress progress)
         {
             this.progress = progress;
 
-            this.groupBox = new GroupBox()
+            index = downloadsForm.progressGridView.Rows.Add(progress.fileName, progress.percentageDone, progress.url, "? Bytes");
+
+            if (progress.totalSize > 1)
             {
-                Anchor = AnchorStyles.Top,
-                Size = new Size(428, 105),
-                Location = new Point(12, CurrentDownloads.nextY),
-                Text = ""
-            };
-
-            downloadsForm.panel1.Controls.Add(groupBox);
-
-            groupBox.Controls.Add(progressBar);
-            groupBox.Controls.Add(title1);
-            groupBox.Controls.Add(fileNameLabel);
-            groupBox.Controls.Add(title2);
-            groupBox.Controls.Add(fileUrlLabel);
-            groupBox.Controls.Add(title3);
-            groupBox.Controls.Add(fileSizeLabel);
-            groupBox.Controls.Add(title4);
-            groupBox.Controls.Add(fileProgressLabel);
+                downloadsForm.progressGridView.Rows[index].Cells[3].Value = progress.fileSize + " Bytes";
+            }
 
             timer.Tick += UpdateTimer_Tick;
             timer.Interval = 500;
@@ -145,35 +39,26 @@ namespace DownloadManager
             }
             else
             {
-                // Update the labels
-                fileNameLabel.Text = progress.fileName;
-                fileUrlLabel.Text = progress.url;
+                // Update the values
+                downloadsForm.progressGridView.Rows[index].Cells[0].Value = progress.fileName;
+                downloadsForm.progressGridView.Rows[index].Cells[2].Value = progress.url;
                 if (progress.totalSize < 1)
                 {
-                    fileSizeLabel.Text = "? Bytes";
+                    downloadsForm.progressGridView.Rows[index].Cells[3].Value = "? Bytes";
                 }
                 else
                 {
-                    fileSizeLabel.Text = progress.fileSize + " Bytes";
+                    downloadsForm.progressGridView.Rows[index].Cells[3].Value = progress.fileSize + " Bytes";
                 }
 
                 if (progress.downloadType == DownloadProgress.DownloadType.YoutubePlaylist)
                 {
-                    // Update the progress bar
-                    progressBar.Style = ProgressBarStyle.Blocks;
-                    progressBar.Minimum = progress.totalProgressBar.Minimum;
-                    progressBar.Maximum = progress.totalProgressBar.Maximum;
-                    progressBar.Value = progress.totalProgressBar.Value;
-
-                    // Update the progress label
-                    int percent = (int)(((double)progressBar.Value / (double)progressBar.Maximum) * 100);
-                    fileProgressLabel.Text = $"{percent}%";
+                    // Update the progressBar
+                    downloadsForm.progressGridView.Rows[index].Cells[1].Value = (int)progress.progressLabel.Text.Replace("%", "").ToDouble();
                 }
                 else if (progress.downloadType == DownloadProgress.DownloadType.YoutubeVideo)
                 {
-                    progressBar.Style = ProgressBarStyle.Marquee;
-                    progressBar.MarqueeAnim = true;
-                    progressBar.ShowText = false;
+                    downloadsForm.progressGridView.Rows[index].Cells[1].Tag = -1;
                 }
                 else
                 {
@@ -188,79 +73,32 @@ namespace DownloadManager
                     {
                         // If the total size is less than 1, then we cannot report progress
                         // Update the progress bar
-                        progressBar.Style = ProgressBarStyle.Marquee;
-                        progressBar.MarqueeAnim = true;
-
-                        // Update the progress label
-                        fileProgressLabel.Text = $"Progress report unavailable.";
+                        downloadsForm.progressGridView.Rows[index].Cells[1].Tag = -1;
                     }
                     else
                     {
                         // Update the progress bar
-                        progressBar.Style = ProgressBarStyle.Blocks;
-                        progressBar.Minimum = 0;
-                        progressBar.Maximum = 100;
-                        progressBar.Value = progress.totalProgress;
-
-                        // Update the progress label
-                        int percent = (int)(((double)progressBar.Value / (double)progressBar.Maximum) * 100);
-                        fileProgressLabel.Text = $"{percent}%";
+                        downloadsForm.progressGridView.Rows[index].Cells[1].Tag = (int)progress.progressLabel.Text.Replace("%", "").ToDouble();
                     }
+
+                    //Logging.Log(((int)progress.progressLabel.Text.Replace("%", "").ToDouble()).ToString(), Color.Gray);
                 }
-
-                // Bring all labels to front
-                fileNameLabel.BringToFront();
-                fileUrlLabel.BringToFront();
-                fileSizeLabel.BringToFront();
-                fileProgressLabel.BringToFront();
-            }
-
-            if (progress.isPaused)
-            {
-                progressBar.State = ProgressBarState.Warning;
-            }
-            else
-            {
-                progressBar.State = ProgressBarState.Normal;
             }
         }
 
         public void Dispose()
         {
             downloadsForm.itemList.Remove(this);
+            downloadsForm.progressGridView.Rows.RemoveAt(index);
 
             timer.Stop();
             timer.Dispose();
-
-            downloadsForm.Controls.Remove(groupBox);
-            groupBox.Dispose();
-            progressBar.Dispose();
-            title1.Dispose();
-            fileNameLabel.Dispose();
-            title2.Dispose();
-            fileUrlLabel.Dispose();
-            title3.Dispose();
-            fileSizeLabel.Dispose();
-            title4.Dispose();
-            fileProgressLabel.Dispose();
         }
 
         public void DisposeNoRemove()
         {
             timer.Stop();
             timer.Dispose();
-
-            downloadsForm.Controls.Remove(groupBox);
-            groupBox.Dispose();
-            progressBar.Dispose();
-            title1.Dispose();
-            fileNameLabel.Dispose();
-            title2.Dispose();
-            fileUrlLabel.Dispose();
-            title3.Dispose();
-            fileSizeLabel.Dispose();
-            title4.Dispose();
-            fileProgressLabel.Dispose();
         }
     }
 }

--- a/DownloadManager.csproj
+++ b/DownloadManager.csproj
@@ -47,10 +47,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Content Include="Properties\Resources\icon.ico" />
-  </ItemGroup>
-
-  <ItemGroup>
     <PackageReference Include="Microsoft.Toolkit.Uwp.Notifications" Version="7.1.3" />
     <PackageReference Include="Microsoft.Web.WebView2" Version="1.0.2151.40" />
     <PackageReference Include="YoutubeExplode" Version="6.3.7" />
@@ -89,10 +85,6 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Update="README.md">
-      <Pack>True</Pack>
-      <PackagePath>\</PackagePath>
-    </None>
-    <None Update="Properties\Resources\icon.png">
       <Pack>True</Pack>
       <PackagePath>\</PackagePath>
     </None>

--- a/DownloadManager.csproj
+++ b/DownloadManager.csproj
@@ -47,7 +47,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Content Include="Resources\icon.ico" />
+    <Content Include="Properties\Resources\icon.ico" />
   </ItemGroup>
 
   <ItemGroup>
@@ -61,6 +61,11 @@
       <DesignTime>True</DesignTime>
       <AutoGen>True</AutoGen>
       <DependentUpon>Resources.resx</DependentUpon>
+    </Compile>
+    <Compile Update="Properties\Settings.Designer.cs">
+      <DesignTimeSharedInput>True</DesignTimeSharedInput>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>Settings.settings</DependentUpon>
     </Compile>
     <Compile Update="Settings.Designer.cs">
       <DesignTimeSharedInput>True</DesignTimeSharedInput>
@@ -87,9 +92,13 @@
       <Pack>True</Pack>
       <PackagePath>\</PackagePath>
     </None>
-    <None Update="Resources\icon.png">
+    <None Update="Properties\Resources\icon.png">
       <Pack>True</Pack>
       <PackagePath>\</PackagePath>
+    </None>
+    <None Update="Properties\Settings.settings">
+      <Generator>SettingsSingleFileGenerator</Generator>
+      <LastGenOutput>Settings.Designer.cs</LastGenOutput>
     </None>
     <None Update="Settings.settings">
       <Generator>SettingsSingleFileGenerator</Generator>

--- a/DownloadProgress.cs
+++ b/DownloadProgress.cs
@@ -110,6 +110,21 @@ namespace DownloadManager
             url = urlArg;
         }
 
+        protected override void WndProc(ref Message m)
+        {
+            const int WM_SYSCOMMAND = 0x0112;
+            const int SC_MINIMIZE = 0xF020;
+
+            if (m.Msg == WM_SYSCOMMAND && (int)m.WParam == SC_MINIMIZE)
+            {
+                this.Hide(); // Hide the form
+                return; // Don't continue with the default processing
+            }
+
+            base.WndProc(ref m);
+        }
+
+
         private void progress_Load(object sender, EventArgs e)
         {
             Log("Preparing to start downloading...", Color.White);
@@ -2585,7 +2600,7 @@ namespace DownloadManager
             }
         }
 
-        private void cancelButton_Click(object sender, EventArgs e)
+        public void cancelButton_Click(object sender, EventArgs e)
         {
             // Close
             if (!downloading)

--- a/DownloadProgress.cs
+++ b/DownloadProgress.cs
@@ -1494,6 +1494,7 @@ namespace DownloadManager
                         this.Text = $"Downloading {fileName}... (100%)";
                         progressLabel.Text = $"100%";
                         bytesLabel.Text = $"({totalSize} B / {totalSize} B)";
+                        speedLabel.Visible = false;
                     }));
 
                     await CombineFilesIntoSingleFile(location + fileName + ".download0", location + fileName + ".download1", location + fileName);

--- a/Settings.Designer.cs
+++ b/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace DownloadManager {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "17.8.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "17.7.0.0")]
     internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));

--- a/Settings.Designer.cs
+++ b/Settings.Designer.cs
@@ -213,5 +213,17 @@ namespace DownloadManager {
                 this["maxServerFailureCount"] = value;
             }
         }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("495, 519")]
+        public global::System.Drawing.Size currentDownloadsSize {
+            get {
+                return ((global::System.Drawing.Size)(this["currentDownloadsSize"]));
+            }
+            set {
+                this["currentDownloadsSize"] = value;
+            }
+        }
     }
 }

--- a/Settings.Designer.cs
+++ b/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace DownloadManager {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "17.7.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "17.8.0.0")]
     internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));
@@ -223,6 +223,28 @@ namespace DownloadManager {
             }
             set {
                 this["currentDownloadsSize"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        public global::System.Collections.Specialized.StringCollection currentDownloadsHiddenColumns {
+            get {
+                return ((global::System.Collections.Specialized.StringCollection)(this["currentDownloadsHiddenColumns"]));
+            }
+            set {
+                this["currentDownloadsHiddenColumns"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        public global::System.Collections.Specialized.StringCollection currentDownloadsShownColumns {
+            get {
+                return ((global::System.Collections.Specialized.StringCollection)(this["currentDownloadsShownColumns"]));
+            }
+            set {
+                this["currentDownloadsShownColumns"] = value;
             }
         }
     }

--- a/Settings.settings
+++ b/Settings.settings
@@ -50,5 +50,8 @@
     <Setting Name="maxServerFailureCount" Type="System.Int32" Scope="User">
       <Value Profile="(Default)">5</Value>
     </Setting>
+    <Setting Name="currentDownloadsSize" Type="System.Drawing.Size" Scope="User">
+      <Value Profile="(Default)">495, 519</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/Settings.settings
+++ b/Settings.settings
@@ -53,5 +53,11 @@
     <Setting Name="currentDownloadsSize" Type="System.Drawing.Size" Scope="User">
       <Value Profile="(Default)">495, 519</Value>
     </Setting>
+    <Setting Name="currentDownloadsHiddenColumns" Type="System.Collections.Specialized.StringCollection" Scope="User">
+      <Value Profile="(Default)" />
+    </Setting>
+    <Setting Name="currentDownloadsShownColumns" Type="System.Collections.Specialized.StringCollection" Scope="User">
+      <Value Profile="(Default)" />
+    </Setting>
   </Settings>
 </SettingsFile>


### PR DESCRIPTION
## Description of changes
This pull request makes a more compact view of downloads in the `CurrentDownloads` window to make it easier to see multiple downloads happening at once.
More controls may be implemented on the new updated `CurrentDownloads` view at a later time.