### PR TITLE
Improve CrashHandler

### DIFF
--- a/Download Manager/Components/DebugForm.Designer.cs
+++ b/Download Manager/Components/DebugForm.Designer.cs
@@ -34,10 +34,10 @@ namespace DownloadManager.Components
             pictureBox1 = new PictureBox();
             darkTabControl = new DownloadManager.Controls.DarkTabControl();
             crashHandlerPage = new TabPage();
+            checkBox1 = new CheckBox();
             button2 = new Button();
             button1 = new Button();
             tabPage2 = new TabPage();
-            checkBox1 = new CheckBox();
             ((System.ComponentModel.ISupportInitialize)pictureBox1).BeginInit();
             darkTabControl.SuspendLayout();
             crashHandlerPage.SuspendLayout();
@@ -94,6 +94,19 @@ namespace DownloadManager.Components
             crashHandlerPage.Text = "CrashHandler";
             crashHandlerPage.UseVisualStyleBackColor = true;
             // 
+            // checkBox1
+            // 
+            checkBox1.AutoSize = true;
+            checkBox1.Checked = true;
+            checkBox1.CheckState = CheckState.Checked;
+            checkBox1.Location = new Point(6, 35);
+            checkBox1.Name = "checkBox1";
+            checkBox1.Size = new Size(212, 20);
+            checkBox1.TabIndex = 2;
+            checkBox1.Text = "Program.allowBypassCrashHandler";
+            checkBox1.UseVisualStyleBackColor = true;
+            checkBox1.CheckedChanged += checkBox1_CheckedChanged;
+            // 
             // button2
             // 
             button2.Location = new Point(87, 6);
@@ -102,6 +115,7 @@ namespace DownloadManager.Components
             button2.TabIndex = 1;
             button2.Text = "Test Crash Ext";
             button2.UseVisualStyleBackColor = true;
+            button2.Click += button2_Click;
             // 
             // button1
             // 
@@ -122,19 +136,6 @@ namespace DownloadManager.Components
             tabPage2.TabIndex = 1;
             tabPage2.Text = "tabPage2";
             tabPage2.UseVisualStyleBackColor = true;
-            // 
-            // checkBox1
-            // 
-            checkBox1.AutoSize = true;
-            checkBox1.Checked = true;
-            checkBox1.CheckState = CheckState.Checked;
-            checkBox1.Location = new Point(6, 35);
-            checkBox1.Name = "checkBox1";
-            checkBox1.Size = new Size(212, 20);
-            checkBox1.TabIndex = 2;
-            checkBox1.Text = "Program.allowBypassCrashHandler";
-            checkBox1.UseVisualStyleBackColor = true;
-            checkBox1.CheckedChanged += checkBox1_CheckedChanged;
             // 
             // DebugForm
             // 

--- a/Download Manager/Components/DebugForm.Designer.cs
+++ b/Download Manager/Components/DebugForm.Designer.cs
@@ -1,0 +1,169 @@
+﻿
+namespace DownloadManager.Components
+{
+    partial class DebugForm
+    {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(DebugForm));
+            richTextBox1 = new RichTextBox();
+            pictureBox1 = new PictureBox();
+            darkTabControl = new DownloadManager.Controls.DarkTabControl();
+            crashHandlerPage = new TabPage();
+            button2 = new Button();
+            button1 = new Button();
+            tabPage2 = new TabPage();
+            checkBox1 = new CheckBox();
+            ((System.ComponentModel.ISupportInitialize)pictureBox1).BeginInit();
+            darkTabControl.SuspendLayout();
+            crashHandlerPage.SuspendLayout();
+            SuspendLayout();
+            // 
+            // richTextBox1
+            // 
+            richTextBox1.BackColor = Color.Black;
+            richTextBox1.BorderStyle = BorderStyle.None;
+            richTextBox1.ForeColor = Color.White;
+            richTextBox1.Location = new Point(48, 12);
+            richTextBox1.Name = "richTextBox1";
+            richTextBox1.ReadOnly = true;
+            richTextBox1.ScrollBars = RichTextBoxScrollBars.Vertical;
+            richTextBox1.Size = new Size(447, 32);
+            richTextBox1.TabIndex = 1001;
+            richTextBox1.Text = "This form is used for debugging Download Manager, some options here may distrupt current downloads or make Download Manager behave unexpectedly.";
+            // 
+            // pictureBox1
+            // 
+            pictureBox1.BackColor = Color.Transparent;
+            pictureBox1.BackgroundImage = Properties.Resources.warn;
+            pictureBox1.BackgroundImageLayout = ImageLayout.Zoom;
+            pictureBox1.Location = new Point(12, 12);
+            pictureBox1.Name = "pictureBox1";
+            pictureBox1.Size = new Size(30, 32);
+            pictureBox1.TabIndex = 1000;
+            pictureBox1.TabStop = false;
+            // 
+            // darkTabControl
+            // 
+            darkTabControl.Controls.Add(crashHandlerPage);
+            darkTabControl.Controls.Add(tabPage2);
+            darkTabControl.DrawMode = TabDrawMode.OwnerDrawFixed;
+            darkTabControl.Location = new Point(12, 62);
+            darkTabControl.Name = "darkTabControl";
+            darkTabControl.SelectedIndex = 0;
+            darkTabControl.Size = new Size(776, 376);
+            darkTabControl.TabBackColor = Color.FromArgb(31, 31, 31);
+            darkTabControl.TabForeColor = Color.FromArgb(241, 241, 241);
+            darkTabControl.TabIndex = 1002;
+            darkTabControl.TextAlign = ContentAlignment.TopLeft;
+            // 
+            // crashHandlerPage
+            // 
+            crashHandlerPage.Controls.Add(checkBox1);
+            crashHandlerPage.Controls.Add(button2);
+            crashHandlerPage.Controls.Add(button1);
+            crashHandlerPage.Location = new Point(4, 25);
+            crashHandlerPage.Name = "crashHandlerPage";
+            crashHandlerPage.Padding = new Padding(3);
+            crashHandlerPage.Size = new Size(768, 347);
+            crashHandlerPage.TabIndex = 0;
+            crashHandlerPage.Text = "CrashHandler";
+            crashHandlerPage.UseVisualStyleBackColor = true;
+            // 
+            // button2
+            // 
+            button2.Location = new Point(87, 6);
+            button2.Name = "button2";
+            button2.Size = new Size(94, 23);
+            button2.TabIndex = 1;
+            button2.Text = "Test Crash Ext";
+            button2.UseVisualStyleBackColor = true;
+            // 
+            // button1
+            // 
+            button1.Location = new Point(6, 6);
+            button1.Name = "button1";
+            button1.Size = new Size(75, 23);
+            button1.TabIndex = 0;
+            button1.Text = "Test Crash";
+            button1.UseVisualStyleBackColor = true;
+            button1.Click += button1_Click;
+            // 
+            // tabPage2
+            // 
+            tabPage2.Location = new Point(4, 25);
+            tabPage2.Name = "tabPage2";
+            tabPage2.Padding = new Padding(3);
+            tabPage2.Size = new Size(768, 347);
+            tabPage2.TabIndex = 1;
+            tabPage2.Text = "tabPage2";
+            tabPage2.UseVisualStyleBackColor = true;
+            // 
+            // checkBox1
+            // 
+            checkBox1.AutoSize = true;
+            checkBox1.Checked = true;
+            checkBox1.CheckState = CheckState.Checked;
+            checkBox1.Location = new Point(6, 35);
+            checkBox1.Name = "checkBox1";
+            checkBox1.Size = new Size(212, 20);
+            checkBox1.TabIndex = 2;
+            checkBox1.Text = "Program.allowBypassCrashHandler";
+            checkBox1.UseVisualStyleBackColor = true;
+            checkBox1.CheckedChanged += checkBox1_CheckedChanged;
+            // 
+            // DebugForm
+            // 
+            AutoScaleDimensions = new SizeF(7F, 16F);
+            AutoScaleMode = AutoScaleMode.Font;
+            ClientSize = new Size(800, 450);
+            Controls.Add(darkTabControl);
+            Controls.Add(richTextBox1);
+            Controls.Add(pictureBox1);
+            FormBorderStyle = FormBorderStyle.FixedSingle;
+            Icon = (Icon)resources.GetObject("$this.Icon");
+            Name = "DebugForm";
+            Text = "DebugForm";
+            ((System.ComponentModel.ISupportInitialize)pictureBox1).EndInit();
+            darkTabControl.ResumeLayout(false);
+            crashHandlerPage.ResumeLayout(false);
+            crashHandlerPage.PerformLayout();
+            ResumeLayout(false);
+        }
+
+        #endregion
+
+        private RichTextBox richTextBox1;
+        private PictureBox pictureBox1;
+        private Controls.DarkTabControl darkTabControl;
+        private TabPage crashHandlerPage;
+        private TabPage tabPage2;
+        private Button button2;
+        private Button button1;
+        private CheckBox checkBox1;
+    }
+}

--- a/Download Manager/Components/DebugForm.cs
+++ b/Download Manager/Components/DebugForm.cs
@@ -1,0 +1,22 @@
+﻿namespace DownloadManager.Components
+{
+    public partial class DebugForm : Form
+    {
+        public DebugForm()
+        {
+            InitializeComponent();
+        }
+
+        // Crash test
+        public void button1_Click(object sender, EventArgs e)
+        {
+            throw new Exception("Manually Initiated Crash");
+        }
+
+        // Allow bypassing crash handler with debugger attached (default: true)
+        private void checkBox1_CheckedChanged(object sender, EventArgs e)
+        {
+            Program.allowBypassCrashHandler = checkBox1.Checked;
+        }
+    }
+}

--- a/Download Manager/Components/DebugForm.cs
+++ b/Download Manager/Components/DebugForm.cs
@@ -13,6 +13,19 @@
             throw new Exception("Manually Initiated Crash");
         }
 
+        // Crash test extended
+        private void button2_Click(object sender, EventArgs e)
+        {
+            try
+            {
+                throw new Exception("This is a test inner exception.\nTest text.");
+            }
+            catch (Exception ex)
+            {
+                throw new Exception("Manually Initiated Crash\nLine 2.\nLine 3\nLine 4", ex);
+            }
+        }
+
         // Allow bypassing crash handler with debugger attached (default: true)
         private void checkBox1_CheckedChanged(object sender, EventArgs e)
         {

--- a/Download Manager/Components/DebugForm.resx
+++ b/Download Manager/Components/DebugForm.resx
@@ -1,0 +1,183 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!--
+    Microsoft ResX Schema
+
+    Version 2.0
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
+    associated with the data types.
+
+    Example:
+
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+
+    There are any number of "resheader" rows that contain simple
+    name/value pairs.
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
+    mimetype set.
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
+    extensible. For a given mimetype the value must be set accordingly:
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
+    read any of the formats listed below.
+
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <data name="$this.Icon" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        AAABAAEAHRwAAAEAIABIDQAAFgAAACgAAAAdAAAAOAAAAAEAIAAAAAAAsAwAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD/AAT//wAE//8ABP//AAT//wAE//8ABP//AAT//wAE//8A
+        BP//AAT//wAE//8ABP//AAT//wAE//8ABP//AAT//wAE/wAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAA/wAE//8ABP//AAT//wAE//8ABP//AAT//wAE//8ABP//AAT//wAE//8A
+        BP//AAT//wAE//8ABP//AAT//wAE//8ABP//AAT//wAE/wAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAP8ABP//////////////////////////////////////////////////////////////
+        /////////////////////////////////////////wAE/wAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAD/AAT//wAE////////////////////////////////////////////////////////////////////
+        ////////////////////////////////////AAT//wAE/wAAAAAAAAAAAAAAAAAAAAAAAAAA/wAE//8A
+        BP//AAT/////////////AAT//wAE//8ABP//AAT//wAE//8ABP//AAT//wAE//8ABP//AAT//wAE//8A
+        BP//AAT//wAE//8ABP////////////8ABP//AAT//wAE/wAAAAAAAAAAAAAAAP8ABP//AAT//wAE//8A
+        BP////////////8ABP//AAT//wAE//8ABP//AAT//wAE//8ABP///////wAE//8ABP//AAT//wAE//8A
+        BP//AAT//wAE/////////////wAE//8ABP//AAT//wAE/wAAAAD/AAT//wAE//8ABP//AAT//wAE////
+        /////////wAE//8ABP//AAT//wAE//8ABP////////////////////////////8ABP//AAT//wAE//8A
+        BP//AAT/////////////AAT//wAE//8ABP//AAT//wAE//8ABP//AAT//wAE//8ABP//AAT/////////
+        ////AAT//wAE//8ABP//AAT///////////////////////////////////////8ABP//AAT//wAE//8A
+        BP////////////8ABP//AAT//wAE//8ABP//AAT//wAE//8ABP//AAT//wAE//8ABP////////////8A
+        BP//AAT//wAE//////////////////////////////////////////////////8ABP//AAT//wAE////
+        /////////wAE//8ABP//AAT//wAE//8ABP//AAT//wAE//8ABP//AAT//wAE/////////////wAE//8A
+        BP////////////////////////////////////////////////////////////8ABP//AAT/////////
+        ////AAT//wAE//8ABP//AAT//wAE//8ABP//AAT//wAE//8ABP//AAT/////////////AAT/////////
+        //////////////////////////////////////////////////////////////8ABP////////////8A
+        BP//AAT//wAE//8ABP//AAT//wAE//8ABP//AAT//wAE//8ABP//AAT//wAE//8ABP//////////////
+        /////////////////////////////////////////////////////////wAE//8ABP//AAT//wAE//8A
+        BP//AAT//wAE//8ABP//AAT//wAE//8ABP//AAT//wAE//8ABP//AAT//wAE//8ABP//AAT//wAE//8A
+        BP////////////////////////////8ABP//AAT//wAE//8ABP//AAT//wAE//8ABP//AAT//wAE//8A
+        BP//AAT//wAE//8ABP//AAT//wAE//8ABP//AAT//wAE//8ABP//AAT//wAE//8ABP//AAT//wAE////
+        /////////////////////////wAE//8ABP//AAT//wAE//8ABP//AAT//wAE//8ABP//AAT//wAE//8A
+        BP//AAT//wAE//8ABP//AAT//wAE//8ABP//AAT//wAE//8ABP//AAT//wAE//8ABP//AAT/////////
+        ////////////////////AAT//wAE//8ABP//AAT//wAE//8ABP//AAT//wAE//8ABP//AAT//wAE//8A
+        BP//AAT//wAE//8ABP//AAT//wAE//8ABP//AAT//wAE//8ABP//AAT//wAE//8ABP//////////////
+        //////////////8ABP//AAT//wAE//8ABP//AAT//wAE//8ABP//AAT//wAE//8ABP//AAT//wAE//8A
+        BP//AAT//wAE//8ABP//AAT//wAE//8ABP//AAT//wAE//8ABP//AAT//wAE////////////////////
+        /////////wAE//8ABP//AAT//wAE//8ABP//AAT//wAE//8ABP//AAT//wAE//8ABP//AAT//wAE//8A
+        BP//AAT//wAE//8ABP//AAT//wAE//8ABP//AAT//wAE//8ABP//AAT/////////////////////////
+        ////AAT//wAE//8ABP//AAT//wAE//8ABP//AAT//wAE//8ABP//AAT//wAE//8ABP//AAT//wAE//8A
+        BP//AAT//wAE//8ABP//AAT//wAE//8ABP//AAT//wAE//8ABP////////////////////////////8A
+        BP//AAT//wAE//8ABP//AAT//wAE//8ABP//AAT//wAE//8ABP//AAT//wAE//8ABP//AAT//wAE//8A
+        BP//AAT//wAE//8ABP//AAT//wAE//8ABP//AAT//wAE/////////////////////////////wAE//8A
+        BP//AAT//wAE//8ABP//AAT//wAE//8ABP//AAT//wAE//8ABP//AAT//wAE//8ABP//AAT//wAE//8A
+        BP//AAT//wAE//8ABP//AAT//wAE//8ABP//AAT/////////////////////////////AAT//wAE//8A
+        BP//AAT//wAE//8ABP//AAT//wAE//8ABP//AAT//wAE//8ABP//AAT//wAE//8ABP//AAT//wAE//8A
+        BP//AAT//wAE//8ABP//AAT//wAE//8ABP////////////////////////////8ABP//AAT//wAE//8A
+        BP//AAT//wAE//8ABP//AAT//wAE//8ABP//AAT//wAE/wAAAAD/AAT//wAE//8ABP//AAT//wAE//8A
+        BP//AAT//wAE//8ABP//AAT//wAE/////////////////////////////wAE//8ABP//AAT//wAE//8A
+        BP//AAT//wAE//8ABP//AAT//wAE//8ABP8AAAAAAAAAAAAAAAD/AAT//wAE//8ABP//AAT//wAE//8A
+        BP//AAT//wAE//8ABP//AAT/////////////////////////////AAT//wAE//8ABP//AAT//wAE//8A
+        BP//AAT//wAE//8ABP//AAT/AAAAAAAAAAAAAAAAAAAAAAAAAAD/AAT//wAE//8ABP//AAT//wAE//8A
+        BP//AAT//wAE//8ABP////////////////////////////8ABP//AAT//wAE//8ABP//AAT//wAE//8A
+        BP//AAT//wAE/wAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD/AAT//wAE//8ABP//AAT//wAE//8A
+        BP//AAT//wAE/////////////////////////////wAE//8ABP//AAT//wAE//8ABP//AAT//wAE//8A
+        BP8AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD/AAT//wAE//8ABP//AAT//wAE//8A
+        BP//AAT//wAE//8ABP//AAT//wAE//8ABP//AAT//wAE//8ABP//AAT//wAE//8ABP//AAT/AAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD/AAT//wAE//8ABP//AAT//wAE//8A
+        BP//AAT//wAE//8ABP//AAT//wAE//8ABP//AAT//wAE//8ABP//AAT//wAE/wAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAPwAAfj4AAD48AAAeOAAADjAAAAYgAAACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACAAAAIwAAAGOAAADjwAAB4+AAA+PwA
+        Afg=
+</value>
+  </data>
+</root>

--- a/Download Manager/Components/Extentions/Exception.cs
+++ b/Download Manager/Components/Extentions/Exception.cs
@@ -1,0 +1,43 @@
+﻿namespace DownloadManager.Components.Extentions
+{
+    public static class ExceptionExt
+    {
+        /// <summary>
+        /// Get all inner exceptions of an exception.
+        /// </summary>
+        /// <param name="ex">Any exception.</param>
+        /// <returns>An array of Exceptions contained in the InnerExceptions property of the specified Exception. If there are no inner exceptions, returns null.</returns>
+        public static Exception[]? GetInnerExceptions(this Exception ex)
+        {
+            if (ex == null)
+            {
+                // If the exception object is null, return null (as there wont be any InnerException)
+                return null;
+            }
+
+            // Declare variables
+            Exception currentException = ex;
+            List<Exception> exceptions = new List<Exception>();
+            Exception[]? exceptionsArray = null;
+
+            while (currentException != null)
+            {
+                // Set the current exception to the next inner exception of the current exception
+                currentException = currentException.InnerException;
+                if (currentException != null)
+                {
+                    // While there are inner exceptions and they are not null, add them to the list
+                    exceptions.Add(currentException);
+                }
+            }
+
+            // If there are inner exceptions, convert the list to an array
+            if (exceptions.Count > 0)
+                exceptionsArray = exceptions.ToArray();
+
+            // Return the array of inner exceptions
+            // If there are no inner exceptions, the array will be null
+            return exceptionsArray;
+        }
+    }
+}

--- a/Download Manager/Controls/DarkTabControl.cs
+++ b/Download Manager/Controls/DarkTabControl.cs
@@ -190,11 +190,16 @@ namespace DownloadManager.Controls
 
         protected override void Dispose(bool disposing)
         {
-            _backBrush.Dispose();
-            _tabBackBrush.Dispose();
-            _tabForeBrush.Dispose();
+            try
+            {
+                _backBrush.Dispose();
+                _tabBackBrush.Dispose();
+                _tabForeBrush.Dispose();
 
-            base.Dispose(disposing);
+                base.Dispose(disposing);
+            }
+            catch (ObjectDisposedException) { }
+            catch (NullReferenceException) { }
         }
 
         private StringFormat _tabTextFormat = new StringFormat();

--- a/Download Manager/DownloadForm.Designer.cs
+++ b/Download Manager/DownloadForm.Designer.cs
@@ -404,12 +404,14 @@
             Controls.Add(label1);
             FormBorderStyle = FormBorderStyle.FixedSingle;
             Icon = (Icon)resources.GetObject("$this.Icon");
+            KeyPreview = true;
             Margin = new Padding(4, 3, 4, 3);
             MaximizeBox = false;
             Name = "DownloadForm";
             Text = "Download Manager";
             FormClosing += DownloadForm_FormClosing;
             Shown += DownloadForm_Shown;
+            KeyDown += DownloadForm_KeyDown;
             Move += DownloadForm_Move;
             trayContextMenu.ResumeLayout(false);
             trayContextMenu.PerformLayout();

--- a/Download Manager/DownloadForm.cs
+++ b/Download Manager/DownloadForm.cs
@@ -392,5 +392,15 @@ namespace DownloadManager
                 catch { }
             }
         }
+
+        private void DownloadForm_KeyDown(object sender, KeyEventArgs e)
+        {
+            // If CRTL+ALT+F3 is pressed and debug mode is enabled
+            if (e.Control && e.Alt && e.KeyCode == Keys.F3 && Program.DEBUG)
+            {
+                Components.DebugForm debugForm = new Components.DebugForm();
+                debugForm.Show();
+            }
+        }
     }
 }

--- a/Download Manager/DownloadForm.resx
+++ b/Download Manager/DownloadForm.resx
@@ -130,36 +130,6 @@
     <value>578, 17</value>
   </metadata>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
-  <data name="toolStripMenuItem1.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
-    <value>
-        iVBORw0KGgoAAAANSUhEUgAAAB0AAAAcCAYAAACdz7SqAAAABGdBTUEAALGPC/xhBQAAALVJREFUSEvt
-        lsEKhTAMBHvw/39ZqVCIwyYxrd46MBfd7IKX91pzONp5rsrOEB6vyG4Jj6iCGcqNBwwrFcwouXXDkKeC
-        Gc+pwa6CmcjyYFfBTOYedVUwk7lHXRXMZO5RVwUzmenoDOygctQez8AOmo5Wh3nD7tejb4dVnt2lUftc
-        4WX5vFsate8szGQd8jc1OrAZPuN7lXH/PXgHFVXHY3DAgy8IBwd/jHJDwk+1IrtDeDwjOwcX0yc3iCi8
-        xmMAAAAASUVORK5CYII=
-</value>
-  </data>
-  <data name="toolStripMenuItem2.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
-    <value>
-        iVBORw0KGgoAAAANSUhEUgAAAB0AAAAcCAYAAACdz7SqAAAABGdBTUEAALGPC/xhBQAAAIxJREFUSEvt
-        lsEOgCAMxfj/n9ZgwsHasQDxtia9dbyjthZwtXadyjen8PhEvq3w6KPBZmWYsWqwEbn1wCjUYBO4N9g1
-        2ExcH+wabBJrNNZgk1ijsQabxBqNNdgk1uiv1miswSZx/ZtqsJm49/dgsAl8DQ4YqQYbkVsvGH802KwM
-        Dnh0It+ewuMd+ebgBsVAe9nXw0aFAAAAAElFTkSuQmCC
-</value>
-  </data>
-  <data name="toolStripMenuItem3.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
-    <value>
-        iVBORw0KGgoAAAANSUhEUgAAAB0AAAAcCAYAAACdz7SqAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAL
-        DAAACwwBP0AiyAAAAaZJREFUSEutliHTAVEUhrcJBJUiin6JGaMqgqIIkiBIgmAEQTDDCMYQFIEqEBWa
-        5HeYOd+cb+fu3X3P3rvX8sy85e55z8O4A88zQJ5H3wZ3WsHyN8HdsQSFbJboeBRLnLJcEi0WbuKgVCgQ
-        XS70z2wml9rCQkWSOCiVy0T3uy4yo5FcHpewUGESB6VKhej1wppPvy8lSUJFsxkVi3KngxUNP8P5JOFk
-        IuallMPvykToVScKcdYq5fDnaKJeTy20Szl8c02cTniisQiTpZz1GlfaSRC6STmHA66Ox0HIcZNmMkTn
-        MyqiOAo5blLOZoMazfPpf21ixxA3qe2WKvhiYc+QZKmLULHdyn5M7FKb8P3GE5/5XO5xkubzRPs9rtPw
-        palW8VQzHsudVikLbzdcownf0kYDn2oGAyGLl34iVGm3cUrT7cr5iDSNUKXXw2lNqyXmtbRWw3GNTagy
-        HGLL5/EgKpWi0shvKi9HXIQq02m0e70SFYtSKP49hMWfCFVWK7/LXxa5nFmoCAZYlkaostuJM3RFwOFf
-        BB2xYOmb4G4rWE4T3Kn4A4N1j/QSrk7eAAAAAElFTkSuQmCC
-</value>
-  </data>
   <data name="trayIcon.Icon" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         AAABAAEAHRwAAAEAIABIDQAAFgAAACgAAAAdAAAAOAAAAAEAIAAAAAAAsAwAAAAAAAAAAAAAAAAAAAAA
@@ -222,6 +192,36 @@
         Afg=
 </value>
   </data>
+  <data name="toolStripMenuItem1.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAAB0AAAAcCAYAAACdz7SqAAAABGdBTUEAALGPC/xhBQAAALVJREFUSEvt
+        lsEKhTAMBHvw/39ZqVCIwyYxrd46MBfd7IKX91pzONp5rsrOEB6vyG4Jj6iCGcqNBwwrFcwouXXDkKeC
+        Gc+pwa6CmcjyYFfBTOYedVUwk7lHXRXMZO5RVwUzmenoDOygctQez8AOmo5Wh3nD7tejb4dVnt2lUftc
+        4WX5vFsate8szGQd8jc1OrAZPuN7lXH/PXgHFVXHY3DAgy8IBwd/jHJDwk+1IrtDeDwjOwcX0yc3iCi8
+        xmMAAAAASUVORK5CYII=
+</value>
+  </data>
+  <data name="toolStripMenuItem2.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAAB0AAAAcCAYAAACdz7SqAAAABGdBTUEAALGPC/xhBQAAAIxJREFUSEvt
+        lsEOgCAMxfj/n9ZgwsHasQDxtia9dbyjthZwtXadyjen8PhEvq3w6KPBZmWYsWqwEbn1wCjUYBO4N9g1
+        2ExcH+wabBJrNNZgk1ijsQabxBqNNdgk1uiv1miswSZx/ZtqsJm49/dgsAl8DQ4YqQYbkVsvGH802KwM
+        Dnh0It+ewuMd+ebgBsVAe9nXw0aFAAAAAElFTkSuQmCC
+</value>
+  </data>
+  <data name="toolStripMenuItem3.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAAB0AAAAcCAYAAACdz7SqAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAL
+        DAAACwwBP0AiyAAAAaZJREFUSEutliHTAVEUhrcJBJUiin6JGaMqgqIIkiBIgmAEQTDDCMYQFIEqEBWa
+        5HeYOd+cb+fu3X3P3rvX8sy85e55z8O4A88zQJ5H3wZ3WsHyN8HdsQSFbJboeBRLnLJcEi0WbuKgVCgQ
+        XS70z2wml9rCQkWSOCiVy0T3uy4yo5FcHpewUGESB6VKhej1wppPvy8lSUJFsxkVi3KngxUNP8P5JOFk
+        IuallMPvykToVScKcdYq5fDnaKJeTy20Szl8c02cTniisQiTpZz1GlfaSRC6STmHA66Ox0HIcZNmMkTn
+        MyqiOAo5blLOZoMazfPpf21ixxA3qe2WKvhiYc+QZKmLULHdyn5M7FKb8P3GE5/5XO5xkubzRPs9rtPw
+        palW8VQzHsudVikLbzdcownf0kYDn2oGAyGLl34iVGm3cUrT7cr5iDSNUKXXw2lNqyXmtbRWw3GNTagy
+        HGLL5/EgKpWi0shvKi9HXIQq02m0e70SFYtSKP49hMWfCFVWK7/LXxa5nFmoCAZYlkaostuJM3RFwOFf
+        BB2xYOmb4G4rWE4T3Kn4A4N1j/QSrk7eAAAAAElFTkSuQmCC
+</value>
+  </data>
   <metadata name="toolTip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>733, 17</value>
   </metadata>
@@ -232,6 +232,9 @@ If the file does not match the provided hash it will be downloaded and verified 
 This is optional and not required for the download. If you do not have a file hash leave this option blank and no file verification will take place.
 If you do have a file hash ensure the combo-box has the correct value or file verification will fail.</value>
   </data>
+  <metadata name="toolTip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>733, 17</value>
+  </metadata>
   <metadata name="openFileDialog.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>830, 17</value>
   </metadata>

--- a/Download Manager/Program.cs
+++ b/Download Manager/Program.cs
@@ -5,7 +5,8 @@ namespace DownloadManager
 {
     internal static class Program
     {
-        private const bool DEBUG = true;
+        public const bool DEBUG = true;
+        public static bool allowBypassCrashHandler = true;
 
         /// <summary>
         ///  The main entry point for the application.
@@ -56,12 +57,18 @@ namespace DownloadManager
             }
             catch (Exception ex)
             {
+                if (Debugger.IsAttached && allowBypassCrashHandler)
+                {
+                    throw;
+                }
+
                 // Define exception information
                 string exceptionType = Convert.ToString(ex.GetType());
                 string exceptionMessage = ex.Message;
                 string[] exceptionStackTraceOld = ex.StackTrace.Split(new string[] { System.Environment.NewLine }, StringSplitOptions.RemoveEmptyEntries);
                 StringBuilder exceptionStackTraceNew = new StringBuilder();
 
+                // Stacktrace
                 foreach (string line in exceptionStackTraceOld)
                 {
                     // Append new StackTrace line to new StackTrace


### PR DESCRIPTION
## Based on issue
#116 

## Description of changes
Improves CrashHandler by making the following changes:
- [x] Allow Download Manager to bypass CrashHandler when a debugger is attached
- [x] Add multi-line support and word wrapping on exception messages
- [x] Add support for inner-exceptions