### PR TITLE
Stop workflows running on `pull_request`

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -13,7 +13,6 @@ name: "CodeQL"
 
 on:
   push:
-  pull_request:
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -40,9 +40,6 @@ name: .NET Core Desktop
 
 on:
   push:
-    #branches: [ master ]
-  pull_request:
-    #branches: [ master ]
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Description of changes
Stops workflows running on `pull_request` and only run on `push` instead.